### PR TITLE
fix: promote mobile navigation and typography updates to main

### DIFF
--- a/app/(site)/astrology/page.tsx
+++ b/app/(site)/astrology/page.tsx
@@ -13,10 +13,10 @@ export default function AstrologyPage() {
             <Star className="h-5 w-5 text-[var(--accent-gold)]" />
             <p className="text-sm uppercase tracking-[0.35em] text-[var(--text-tertiary)]">Celestial Mechanics</p>
           </div>
-          <h1 className="font-serif text-4xl lg:text-5xl text-[var(--text-primary)] mb-4">
+          <h1 className="page-hero-title">
             Elden Ring&apos;s Astrology
           </h1>
-          <p className="text-lg text-[var(--text-secondary)]">
+          <p className="page-hero-description">
             As above, so below. The celestial structure of the Lands Between mirrors
             the cosmic relationships between stars, planets, and the forces that bind them.
           </p>

--- a/app/(site)/bachelor-machines/page.tsx
+++ b/app/(site)/bachelor-machines/page.tsx
@@ -18,10 +18,10 @@ export default function BachelorMachinesPage() {
             <Cog className="h-5 w-5 text-[var(--accent-gold)]" />
             <p className="text-sm uppercase tracking-[0.35em] text-[var(--text-tertiary)]">Theoretical Concept</p>
           </div>
-          <h1 className="font-serif text-4xl lg:text-5xl text-[var(--text-primary)] mb-4">
+          <h1 className="page-hero-title">
             Understanding Bachelor Machines
           </h1>
-          <p className="text-lg text-[var(--text-secondary)]">
+          <p className="page-hero-description">
             The bachelor machine is a closed, self-sufficient system that produces nothing but its own functioning.
             A key concept linking Duchamp&apos;s Large Glass to Elden Ring&apos;s cyclical world.
           </p>

--- a/app/(site)/bachelor-machines/terms/page.tsx
+++ b/app/(site)/bachelor-machines/terms/page.tsx
@@ -25,11 +25,11 @@ export default function BachelorMachineTermsPage() {
               Reference Catalog
             </p>
           </div>
-          <h1 className="font-serif text-4xl lg:text-5xl text-[var(--text-primary)] mb-4">
+          <h1 className="page-hero-title">
             {doc.title}
           </h1>
           {doc.subtitle && (
-            <p className="text-lg text-[var(--text-secondary)]">{doc.subtitle}</p>
+            <p className="page-hero-description">{doc.subtitle}</p>
           )}
         </div>
         <HeroMeta

--- a/app/(site)/belevan/page.tsx
+++ b/app/(site)/belevan/page.tsx
@@ -18,7 +18,7 @@ export default function BelevanPage() {
             <User className="h-5 w-5 text-[var(--accent-purple)]" />
             <p className="text-sm uppercase tracking-[0.35em] text-[var(--text-tertiary)]">Key Figure</p>
           </div>
-          <h1 className="font-serif text-4xl lg:text-5xl text-[var(--text-primary)] mb-4">
+          <h1 className="page-hero-title">
             Mónica Belevan
           </h1>
           <div className="flex gap-4 text-sm">

--- a/app/(site)/chess-research/page.tsx
+++ b/app/(site)/chess-research/page.tsx
@@ -63,10 +63,10 @@ export default function ChessResearchPage() {
             <BookOpen className="h-5 w-5 text-[var(--accent-gold)]" />
             <p className="text-sm uppercase tracking-[0.35em] text-[var(--text-tertiary)]">Research Archive</p>
           </div>
-          <h1 className="font-serif text-4xl lg:text-5xl text-[var(--text-primary)] mb-4">
+          <h1 className="page-hero-title">
             Chess Research
           </h1>
-          <p className="text-lg text-[var(--text-secondary)]">
+          <p className="page-hero-description">
             Scholarly articles about Duchamp&apos;s chess career and its artistic significance from Toutfait: The Marcel Duchamp Studies Online Journal
           </p>
         </div>

--- a/app/(site)/chess/page.tsx
+++ b/app/(site)/chess/page.tsx
@@ -18,10 +18,10 @@ export default function ChessPage() {
             <Crown className="h-5 w-5 text-[var(--accent-gold)]" />
             <p className="text-sm uppercase tracking-[0.35em] text-[var(--text-tertiary)]">Strategic Dimension</p>
           </div>
-          <h1 className="font-serif text-4xl lg:text-5xl text-[var(--text-primary)] mb-4">
+          <h1 className="page-hero-title">
             Duchamp and Chess
           </h1>
-          <p className="text-lg text-[var(--text-secondary)]">
+          <p className="page-hero-description">
             Duchamp famously abandoned art for chess in the 1920s. But was chess itself
             a continuation of his artistic practice by other means?
           </p>

--- a/app/(site)/chocolate-grinder/page.tsx
+++ b/app/(site)/chocolate-grinder/page.tsx
@@ -34,10 +34,10 @@ export default function ChocolateGrinderPage() {
             <CircleDot className="h-5 w-5 text-[var(--accent-gold)]" />
             <p className="text-sm uppercase tracking-[0.35em] text-[var(--text-tertiary)]">Visual Evidence</p>
           </div>
-          <h1 className="font-serif text-4xl lg:text-5xl text-[var(--text-primary)] mb-4">
+          <h1 className="page-hero-title">
             The Chocolate Grinder
           </h1>
-          <p className="text-lg text-[var(--text-secondary)]">
+          <p className="page-hero-description">
             The Elden Ring symbol - the iconic image on every cover and loading screen -
             is Duchamp&apos;s Chocolate Grinder viewed from directly above.
           </p>

--- a/app/(site)/critiques/page.tsx
+++ b/app/(site)/critiques/page.tsx
@@ -19,10 +19,10 @@ export default function CritiquesPage() {
       <section className="glass-card border border-[var(--border-emphasis)] bg-gradient-to-b from-[rgb(var(--bg-secondary-rgb)/0.9)] to-[rgb(var(--bg-secondary-rgb)/0.6)] p-8 lg:p-12">
         <div className="max-w-3xl">
           <p className="text-sm uppercase tracking-[0.35em] text-[var(--text-tertiary)] mb-4">Critical Analysis</p>
-          <h1 className="font-serif text-4xl lg:text-5xl text-[var(--text-primary)] mb-4">
+          <h1 className="page-hero-title">
             Critiques & Responses
           </h1>
-          <p className="text-lg text-[var(--text-secondary)] leading-relaxed">
+          <p className="page-hero-description leading-relaxed">
             This section addresses existing Elden Ring scholarship and community theories. Each critique demonstrates
             how the Duchamp framework recontextualizes and often resolves apparent contradictions in the lore.
           </p>

--- a/app/(site)/daisugi-cosmology/page.tsx
+++ b/app/(site)/daisugi-cosmology/page.tsx
@@ -12,10 +12,10 @@ export default function DaisugiCosmologyPage() {
             <TreeDeciduous className="h-5 w-5 text-[var(--accent-gold)]" />
             <p className="text-sm uppercase tracking-[0.35em] text-[var(--text-tertiary)]">Cosmological Structure</p>
           </div>
-          <h1 className="font-serif text-4xl lg:text-5xl text-[var(--text-primary)] mb-4">
+          <h1 className="page-hero-title">
             The Daisugi Cosmology
           </h1>
-          <p className="text-lg text-[var(--text-secondary)]">
+          <p className="page-hero-description">
             The candelabra tree that spans all of Miyazaki&apos;s worlds. Multiple flames on branching arms, each burning down.
           </p>
         </div>

--- a/app/(site)/duchamp-biography/page.tsx
+++ b/app/(site)/duchamp-biography/page.tsx
@@ -20,10 +20,10 @@ export default function DuchampBiographyPage() {
             <User className="h-5 w-5 text-[var(--accent-gold)]" />
             <p className="text-sm uppercase tracking-[0.35em] text-[var(--text-tertiary)]">Artist Profile</p>
           </div>
-          <h1 className="font-serif text-4xl lg:text-5xl text-[var(--text-primary)] mb-4">
+          <h1 className="page-hero-title">
             Duchamp: Biography &amp; Legacy
           </h1>
-          <p className="text-lg text-[var(--text-secondary)]">
+          <p className="page-hero-description">
             Marcel Duchamp (1887-1968) revolutionized art in the 20th century. Understanding his life
             and methods is essential for understanding what FromSoftware has accomplished.
           </p>

--- a/app/(site)/endings/page.tsx
+++ b/app/(site)/endings/page.tsx
@@ -12,10 +12,10 @@ export default function EndingsPage() {
       <section className="glass-card border border-[var(--border-emphasis)] bg-gradient-to-b from-[rgb(var(--bg-secondary-rgb)/0.9)] to-[rgb(var(--bg-secondary-rgb)/0.6)] p-8 lg:p-12">
         <div className="max-w-3xl">
           <p className="text-sm uppercase tracking-[0.35em] text-[var(--text-tertiary)] mb-4">Analysis</p>
-          <h1 className="font-serif text-4xl lg:text-5xl text-[var(--text-primary)] mb-4">
+          <h1 className="page-hero-title">
             Endings as Post-War Japan
           </h1>
-          <p className="text-lg text-[var(--text-secondary)]">
+          <p className="page-hero-description">
             Elden Ring as allegory for post-war Japan. The endings read through Shuji Terayama, Henrik Ibsen, and Yukio Mishima.
           </p>
         </div>

--- a/app/(site)/golden-bough/page.tsx
+++ b/app/(site)/golden-bough/page.tsx
@@ -18,10 +18,10 @@ export default function GoldenBoughPage() {
             <TreeDeciduous className="h-5 w-5 text-[var(--accent-gold)]" />
             <p className="text-sm uppercase tracking-[0.35em] text-[var(--text-tertiary)]">Mythological Source</p>
           </div>
-          <h1 className="font-serif text-4xl lg:text-5xl text-[var(--text-primary)] mb-4">
+          <h1 className="page-hero-title">
             The Golden Bough
           </h1>
-          <p className="text-lg text-[var(--text-secondary)]">
+          <p className="page-hero-description">
             James George Frazer&apos;s monumental study of magic, religion, and mythology - a key source
             for understanding the deep structures underlying both Duchamp&apos;s art and Elden Ring.
           </p>

--- a/app/(site)/initial-thesis/page.tsx
+++ b/app/(site)/initial-thesis/page.tsx
@@ -27,8 +27,8 @@ export default function InitialThesisPage() {
               <Lock className="h-4 w-4 text-[var(--accent-gold)]" />
               <p className="text-sm uppercase tracking-[0.35em] text-[var(--accent-gold)]">The Initial Thesis</p>
             </div>
-            <h1 className="font-serif text-4xl lg:text-5xl text-[var(--text-primary)]">{doc.title}</h1>
-            {doc.subtitle && <p className="mt-4 text-lg lg:text-xl text-[var(--text-secondary)]">{doc.subtitle}</p>}
+            <h1 className="page-hero-title">{doc.title}</h1>
+            {doc.subtitle && <p className="mt-4 page-hero-description">{doc.subtitle}</p>}
           </div>
           <Button asChild variant="outline" size="sm">
             <a href={`/proofs/${doc.hashableFile}`} download>

--- a/app/(site)/la-chose-en-soie/page.tsx
+++ b/app/(site)/la-chose-en-soie/page.tsx
@@ -17,10 +17,10 @@ export default function LaChoseEnSoiePage() {
             <BookOpen className="h-5 w-5 text-[var(--accent-gold)]" />
             <p className="text-sm uppercase tracking-[0.35em] text-[var(--text-tertiary)]">External Source</p>
           </div>
-          <h1 className="font-serif text-4xl lg:text-5xl text-[var(--text-primary)] mb-4">
+          <h1 className="page-hero-title">
             La Chose en Soie
           </h1>
-          <p className="text-lg text-[var(--text-secondary)] mb-4">
+          <p className="page-hero-description mb-4">
             <em>The Thing in Silk</em> — An analysis of Duchamp&apos;s ready-made philosophy, tracing
             the logical development from the <em>Grand Verre</em> to &quot;the chance encounter on the
             dissection table.&quot;

--- a/app/(site)/large-glass-breakdown/page.tsx
+++ b/app/(site)/large-glass-breakdown/page.tsx
@@ -18,10 +18,10 @@ export default function LargeGlassBreakdownPage() {
             <Quote className="h-5 w-5 text-[var(--accent-gold)]" />
             <p className="text-sm uppercase tracking-[0.35em] text-[var(--text-tertiary)]">Duchamp in His Own Words</p>
           </div>
-          <h1 className="font-serif text-4xl lg:text-5xl text-[var(--text-primary)] mb-4">
+          <h1 className="page-hero-title">
             Selected Quotes on the Large Glass
           </h1>
-          <p className="text-lg text-[var(--text-secondary)]">
+          <p className="page-hero-description">
             Direct quotes from Duchamp&apos;s notes describing the components and geometry of <em>The Bride Stripped Bare by Her Bachelors, Even</em>.
           </p>
         </div>

--- a/app/(site)/living-thesis/page.tsx
+++ b/app/(site)/living-thesis/page.tsx
@@ -22,10 +22,10 @@ export default function LivingThesisPage() {
             <Eye className="h-5 w-5 text-[var(--accent-gold)]" />
             <p className="text-sm uppercase tracking-[0.35em] text-[var(--text-tertiary)]">The Living Thesis</p>
           </div>
-          <h1 className="font-serif text-4xl lg:text-5xl text-[var(--text-primary)] mb-4">
+          <h1 className="page-hero-title">
             {doc.title}
           </h1>
-          <p className="text-lg text-[var(--text-secondary)]">
+          <p className="page-hero-description">
             The current, evolving statement of the discovery. Where the claim from the initial thesis has been expanded, cited, and pressure-tested.
           </p>
         </div>

--- a/app/(site)/master-list/page.tsx
+++ b/app/(site)/master-list/page.tsx
@@ -12,7 +12,7 @@ export default function MasterListPage() {
         <h1 className="text-4xl font-serif text-[var(--text-primary)] mb-4">
           {doc.title}
         </h1>
-        <p className="text-lg text-[var(--text-secondary)]">
+        <p className="page-hero-description">
           {count} Correspondences
         </p>
       </header>

--- a/app/(site)/pataphysics/page.tsx
+++ b/app/(site)/pataphysics/page.tsx
@@ -18,10 +18,10 @@ export default function PataphysicsPage() {
             <Target className="h-5 w-5 text-[var(--accent-blue)]" />
             <p className="text-sm uppercase tracking-[0.35em] text-[var(--text-tertiary)]">Theoretical Framework</p>
           </div>
-          <h1 className="font-serif text-4xl lg:text-5xl text-[var(--text-primary)] mb-4">
+          <h1 className="page-hero-title">
             Understanding &apos;Pataphysics
           </h1>
-          <p className="text-lg text-[var(--text-secondary)]">
+          <p className="page-hero-description">
             The science of imaginary solutions, which symbolically attributes the properties of objects,
             described by their virtuality, to their lineaments. A key to understanding FromSoftware&apos;s artistic vision.
           </p>

--- a/app/(site)/pataphysics/pataphysics-engine/page.tsx
+++ b/app/(site)/pataphysics/pataphysics-engine/page.tsx
@@ -18,10 +18,10 @@ export default function PataphysicsEnginePage() {
             <Gamepad2 className="h-5 w-5 text-[var(--accent-blue)]" />
             <p className="text-sm uppercase tracking-[0.35em] text-[var(--text-tertiary)]">Academic Paper</p>
           </div>
-          <h1 className="font-serif text-4xl lg:text-5xl text-[var(--text-primary)] mb-4">
+          <h1 className="page-hero-title">
             A &apos;Pataphysics Engine
           </h1>
-          <p className="text-lg text-[var(--text-secondary)] mb-2">
+          <p className="page-hero-description mb-2">
             Play, Technology, and Realities
           </p>
           <p className="text-[var(--text-tertiary)]">

--- a/app/(site)/press/page.tsx
+++ b/app/(site)/press/page.tsx
@@ -13,7 +13,7 @@ export default function PressPage() {
       {/* Header */}
       <header className="space-y-4">
         <h1 className="font-serif text-4xl text-[var(--text-primary)]">Press Kit</h1>
-        <p className="text-lg text-[var(--text-secondary)]">
+        <p className="page-hero-description">
           Resources for journalists and content creators covering the discovery that
           Elden Ring is a digital reimagining of Marcel Duchamp&apos;s The Large Glass.
         </p>

--- a/app/(site)/readymades-research/page.tsx
+++ b/app/(site)/readymades-research/page.tsx
@@ -175,10 +175,10 @@ export default function ReadymadesResearchPage() {
             <BookOpen className="h-5 w-5 text-[var(--accent-gold)]" />
             <p className="text-sm uppercase tracking-[0.35em] text-[var(--text-tertiary)]">Research Archive</p>
           </div>
-          <h1 className="font-serif text-4xl lg:text-5xl text-[var(--text-primary)] mb-4">
+          <h1 className="page-hero-title">
             Readymades Research
           </h1>
-          <p className="text-lg text-[var(--text-secondary)]">
+          <p className="page-hero-description">
             Scholarly articles about Duchamp&apos;s readymades from Toutfait: The Marcel Duchamp Studies Online Journal
           </p>
         </div>

--- a/app/(site)/readymades/page.tsx
+++ b/app/(site)/readymades/page.tsx
@@ -18,10 +18,10 @@ export default function ReadymadesPage() {
             <Package className="h-5 w-5 text-[var(--accent-gold)]" />
             <p className="text-sm uppercase tracking-[0.35em] text-[var(--text-tertiary)]">Art Historical Context</p>
           </div>
-          <h1 className="font-serif text-4xl lg:text-5xl text-[var(--text-primary)] mb-4">
+          <h1 className="page-hero-title">
             The Readymades
           </h1>
-          <p className="text-lg text-[var(--text-secondary)]">
+          <p className="page-hero-description">
             Duchamp&apos;s revolutionary gesture: selecting everyday objects and declaring them art.
             Or was it something more complex?
           </p>

--- a/app/(site)/rhonda-shearer-archive/page.tsx
+++ b/app/(site)/rhonda-shearer-archive/page.tsx
@@ -19,10 +19,10 @@ export default function RhondaShearerArchivePage() {
             <User className="h-5 w-5 text-[var(--accent-gold)]" />
             <p className="text-sm uppercase tracking-[0.35em] text-[var(--text-tertiary)]">Key Scholar</p>
           </div>
-          <h1 className="font-serif text-4xl lg:text-5xl text-[var(--text-primary)] mb-4">
+          <h1 className="page-hero-title">
             Rhonda Shearer
           </h1>
-          <p className="text-lg text-[var(--text-secondary)]">
+          <p className="page-hero-description">
             The researcher whose groundbreaking work revealed that Duchamp&apos;s &quot;readymades&quot;
             were often carefully crafted fakes - transforming our understanding of his entire project.
           </p>

--- a/app/(site)/rhonda-shearer/page.tsx
+++ b/app/(site)/rhonda-shearer/page.tsx
@@ -19,10 +19,10 @@ export default function RhondaShearerPage() {
             <User className="h-5 w-5 text-[var(--accent-gold)]" />
             <p className="text-sm uppercase tracking-[0.35em] text-[var(--text-tertiary)]">Key Scholar</p>
           </div>
-          <h1 className="font-serif text-4xl lg:text-5xl text-[var(--text-primary)] mb-4">
+          <h1 className="page-hero-title">
             Rhonda Shearer
           </h1>
-          <p className="text-lg text-[var(--text-secondary)]">
+          <p className="page-hero-description">
             The researcher whose groundbreaking work revealed that Duchamp&apos;s &quot;readymades&quot;
             were often carefully crafted fakes - transforming our understanding of his entire project.
           </p>

--- a/app/(site)/tldr/page.tsx
+++ b/app/(site)/tldr/page.tsx
@@ -26,8 +26,8 @@ export default function TldrPage() {
               <Zap className="h-4 w-4 text-[var(--accent-gold)]" />
               <p className="text-sm uppercase tracking-[0.35em] text-[var(--accent-gold)]">TL;DR</p>
             </div>
-            <h1 className="font-serif text-4xl lg:text-5xl text-[var(--text-primary)]">{doc.title}</h1>
-            {doc.subtitle && <p className="mt-4 text-lg lg:text-xl text-[var(--text-secondary)]">{doc.subtitle}</p>}
+            <h1 className="page-hero-title">{doc.title}</h1>
+            {doc.subtitle && <p className="mt-4 page-hero-description">{doc.subtitle}</p>}
           </div>
           <Button asChild variant="outline" size="sm">
             <a href={`/proofs/${doc.hashableFile}`} download>

--- a/app/(site)/what-is-pataphysics/page.tsx
+++ b/app/(site)/what-is-pataphysics/page.tsx
@@ -18,10 +18,10 @@ export default function WhatIsPataphysicsPage() {
             <HelpCircle className="h-5 w-5 text-[var(--accent-blue)]" />
             <p className="text-sm uppercase tracking-[0.35em] text-[var(--text-tertiary)]">Foundation</p>
           </div>
-          <h1 className="font-serif text-4xl lg:text-5xl text-[var(--text-primary)] mb-4">
+          <h1 className="page-hero-title">
             What is &apos;Pataphysics?
           </h1>
-          <p className="text-lg text-[var(--text-secondary)]">
+          <p className="page-hero-description">
             &apos;Pataphysics is the science of imaginary solutions, which symbolically attributes
             the properties of objects, described by their virtuality, to their lineaments.
           </p>

--- a/app/(site)/xenotext-theory/page.tsx
+++ b/app/(site)/xenotext-theory/page.tsx
@@ -26,10 +26,10 @@ export default function XenotextTheoryPage() {
             <Dna className="h-5 w-5 text-[var(--accent-purple)]" />
             <p className="text-sm uppercase tracking-[0.35em] text-[var(--text-tertiary)]">Research Notes</p>
           </div>
-          <h1 className="font-serif text-4xl lg:text-5xl text-[var(--text-primary)] mb-4">
+          <h1 className="page-hero-title">
             The Xenotext Theory
           </h1>
-          <p className="text-lg text-[var(--text-secondary)]">
+          <p className="page-hero-description">
             Connecting Christian Bök&apos;s <em>The Xenotext</em> to Elden Ring and The Large Glass.
             The xenotext means what interpreters cannot prevent it from meaning.
           </p>

--- a/app/(site)/xenotext/page.tsx
+++ b/app/(site)/xenotext/page.tsx
@@ -534,10 +534,10 @@ export default function XenotextPage() {
             <Dna className="h-5 w-5 text-[var(--accent-gold)]" />
             <p className="text-sm uppercase tracking-[0.35em] text-[var(--text-tertiary)]">Biologically Accurate Model</p>
           </div>
-          <h1 className="font-serif text-4xl lg:text-5xl text-[var(--text-primary)] mb-4">
+          <h1 className="page-hero-title">
             Xenotext Cipher
           </h1>
-          <p className="text-lg text-[var(--text-secondary)]">
+          <p className="page-hero-description">
             The Elden Beast as cosmic code. Modeled after Christian Bök&apos;s Xenotext using actual biological transcription and translation.
           </p>
         </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -185,6 +185,14 @@ body {
 }
 
 @layer components {
+  .page-hero-title {
+    @apply mb-4 font-serif leading-tight text-[var(--text-primary)] text-3xl lg:text-5xl;
+  }
+
+  .page-hero-description {
+    @apply text-base text-[var(--text-secondary)] lg:text-lg;
+  }
+
   .glass-card {
     @apply bg-[var(--bg-secondary)] border border-[var(--border-subtle)] rounded-xl shadow-panel;
   }

--- a/components/site/hero-meta.tsx
+++ b/components/site/hero-meta.tsx
@@ -12,13 +12,13 @@ interface HeroMetaProps {
 
 export function HeroMeta({ items }: HeroMetaProps) {
   return (
-    <div className="mt-4 flex flex-wrap gap-4 text-sm text-[var(--text-tertiary)]">
+    <div className="mt-4 flex flex-wrap gap-3 text-xs text-[var(--text-tertiary)] sm:gap-4 sm:text-sm">
       {items.map(({ label, value, icon: Icon }) => (
         <div key={label} className="flex items-center gap-2">
           <Icon className="h-4 w-4 text-[var(--accent-gold)]" />
           <div>
-            <p className="uppercase text-[0.65rem] tracking-[0.3em]">{label}</p>
-            <p className="text-[var(--text-secondary)]">{value}</p>
+            <p className="text-[0.6rem] uppercase tracking-[0.25em] sm:text-[0.65rem] sm:tracking-[0.3em]">{label}</p>
+            <p className="text-sm text-[var(--text-secondary)] sm:text-base">{value}</p>
           </div>
         </div>
       ))}

--- a/components/site/mobile-sidebar.tsx
+++ b/components/site/mobile-sidebar.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import Image from 'next/image';
-import { ChevronDown, ChevronRight } from 'lucide-react';
-import { useState } from 'react';
+import { ChevronDown } from 'lucide-react';
+import { useMemo, useState } from 'react';
 
 import type { SidebarData } from '@/lib/content';
-import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
-import { SidebarLink } from './sidebar-link';
 import { Badge } from '@/components/ui/badge';
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
+import { NavigationMenu } from './navigation-menu';
+import { getSiteNavigation } from './site-navigation';
 
 interface MobileSidebarProps {
   data: SidebarData;
@@ -15,290 +16,38 @@ interface MobileSidebarProps {
 
 export function MobileSidebar({ data }: MobileSidebarProps) {
   const [open, setOpen] = useState(false);
-  const [openSections, setOpenSections] = useState({
-    scratchWritings: false,
-    xenotextTheory: false,
-    pataphysics: false,
-    duchamp: false,
-    critiques: false,
-    author: false,
-  });
-
-  const toggleSection = (section: keyof typeof openSections) => {
-    setOpenSections(prev => ({ ...prev, [section]: !prev[section] }));
-  };
-
-  const close = () => setOpen(false);
-
-  const livingThesisDateLabel = formatShortDate(data.livingThesis.updated);
+  const navigation = useMemo(() => getSiteNavigation(data), [data]);
 
   return (
     <Sheet open={open} onOpenChange={setOpen}>
       <SheetTrigger asChild>
-        <button className="lg:hidden flex flex-col items-center gap-0 p-1 hover:opacity-80 transition-opacity">
+        <button
+          type="button"
+          aria-label={open ? 'Close navigation' : 'Open navigation'}
+          aria-expanded={open}
+          className="flex items-center gap-2 rounded-lg px-1 py-1 transition-opacity hover:opacity-80 lg:hidden"
+        >
           <Image
             src="/images/dashusnavnulsigil.png"
-            alt="Open navigation"
+            alt=""
             width={56}
             height={56}
             className="opacity-90"
           />
-          <div className="flex flex-col items-center -mt-1">
-            <ChevronDown className="h-3 w-3 text-[var(--accent-gold)] -mb-2" />
-            <ChevronDown className="h-3 w-3 text-[var(--accent-gold)] -mb-2" />
-            <ChevronDown className="h-3 w-3 text-[var(--accent-gold)]" />
+          <div className="flex h-12 w-12 items-center justify-center rounded-md border border-[var(--border-subtle)] bg-[rgb(var(--bg-secondary-rgb)/0.65)]">
+            <ChevronDown className="h-7 w-7 text-[var(--accent-gold)]" />
           </div>
         </button>
       </SheetTrigger>
-      <SheetContent>
+      <SheetContent className="w-[min(24rem,calc(100vw-1rem))] max-w-[calc(100vw-1rem)]">
         <SheetHeader>
-          <SheetTitle className="font-serif text-base text-[var(--accent-gold)] leading-tight">Elden Ring Is Marcel Duchamp&apos;s <em>The Bride Stripped Bare By Her Bachelors, Even</em></SheetTitle>
+          <SheetTitle className="pr-12 font-serif text-base leading-tight text-[var(--accent-gold)]">
+            Elden Ring Is Marcel Duchamp&apos;s <em>The Bride Stripped Bare By Her Bachelors, Even</em>
+          </SheetTitle>
           <Badge>Living Document</Badge>
         </SheetHeader>
-        <div className="mt-6 space-y-6">
-          {/* Primary Navigation */}
-          <div className="space-y-2 pb-4 border-b border-[var(--border-subtle)]">
-            <SidebarLink href="/" label="Home Page" onNavigate={close} />
-            <SidebarLink href="/living-thesis" label="Living Thesis" meta={livingThesisDateLabel} onNavigate={close} />
-            <SidebarLink href="/master-list" label="Master List" meta={`${data.masterList.count} correspondences`} onNavigate={close} />
-            <SidebarLink href="/tldr" label="TL;DR" meta="Bitcoin" onNavigate={close} />
-            <SidebarLink href="/initial-thesis" label="Initial Thesis" meta="Ethereum" onNavigate={close} />
-          </div>
-
-          {/* Errata header */}
-          <div>
-            <p className="text-[0.7rem] uppercase tracking-[0.25em] text-[var(--accent-gold)]">Errata</p>
-          </div>
-
-          {/* Elden Ring Item Cards — direct link */}
-          <SidebarLink
-            href="/gatherer"
-            label="Elden Ring Item Cards"
-            onNavigate={close}
-          />
-
-          {/* Scratch Writings */}
-          <div>
-            <button
-              onClick={() => toggleSection('scratchWritings')}
-              className="flex items-center gap-1 w-full text-left text-[0.7rem] uppercase tracking-[0.2em] text-[var(--text-tertiary)] mb-2 hover:text-[var(--text-secondary)] transition-colors"
-            >
-              {openSections.scratchWritings ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
-              Scratch Writings
-            </button>
-            {openSections.scratchWritings && (
-              <div className="space-y-1">
-                <SidebarLink
-                  href="/belevan"
-                  label="Belevan, Mónica"
-                  onNavigate={close}
-                />
-                <SidebarLink
-                  href="/large-glass-breakdown"
-                  label="Selected Quotes on the Large Glass"
-                  onNavigate={close}
-                />
-                <SidebarLink
-                  href="/duchamp-biography"
-                  label="Duchamp Biography"
-                  onNavigate={close}
-                />
-                <SidebarLink
-                  href="/endings"
-                  label="Endings as Post-War Japan"
-                  onNavigate={close}
-                />
-                <SidebarLink
-                  href="/golden-bough"
-                  label="The Golden Bough"
-                  onNavigate={close}
-                />
-                <SidebarLink
-                  href="/bibliography"
-                  label="Bibliography & Resources"
-                  onNavigate={close}
-                />
-              </div>
-            )}
-          </div>
-
-          {/* Pataphysics */}
-          <div>
-            <button
-              onClick={() => toggleSection('pataphysics')}
-              className="flex items-center gap-1 w-full text-left text-[0.7rem] uppercase tracking-[0.2em] text-[var(--text-tertiary)] mb-2 hover:text-[var(--text-secondary)] transition-colors"
-            >
-              {openSections.pataphysics ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
-              Pataphysics
-            </button>
-            {openSections.pataphysics && (
-            <div className="space-y-1">
-              <SidebarLink
-                href="/bachelor-machines"
-                label="Understanding Bachelor Machines"
-                onNavigate={close}
-              />
-              <SidebarLink
-                href="/pataphysics"
-                label="Understand Pataphysics"
-                onNavigate={close}
-              />
-              <SidebarLink
-                href="/what-is-pataphysics"
-                label="What is Pataphysics?"
-                onNavigate={close}
-              />
-              <SidebarLink
-                href="/vocab"
-                label="Pataphysics Vocabulary"
-                onNavigate={close}
-              />
-            </div>
-            )}
-          </div>
-
-          {/* Theories */}
-          <div>
-            <button
-              onClick={() => toggleSection('xenotextTheory')}
-              className="flex items-center gap-1 w-full text-left text-[0.7rem] uppercase tracking-[0.2em] text-[var(--text-tertiary)] mb-2 hover:text-[var(--text-secondary)] transition-colors"
-            >
-              {openSections.xenotextTheory ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
-              The Xenotext Theory
-            </button>
-            {openSections.xenotextTheory && (
-              <div className="space-y-1">
-                <SidebarLink
-                  href="/xenotext"
-                  label="Xenotext Cipher"
-                  meta="Interactive"
-                  onNavigate={close}
-                />
-                <SidebarLink
-                  href="/xenotext-theory"
-                  label="The Xenotext Theory"
-                  onNavigate={close}
-                />
-                <div className="ml-3 space-y-1">
-                  <SidebarLink
-                    href="/xenotext-theory#flower-crucible-erdtree"
-                    label="Flower Crucible & Erdtree"
-                    onNavigate={close}
-                  />
-                  <SidebarLink
-                    href="/xenotext-theory#flower-maidens"
-                    label="Flower Maidens"
-                    onNavigate={close}
-                  />
-                </div>
-              </div>
-            )}
-          </div>
-
-          {/* Duchamp */}
-          <div>
-            <button
-              onClick={() => toggleSection('duchamp')}
-              className="flex items-center gap-1 w-full text-left text-[0.7rem] uppercase tracking-[0.2em] text-[var(--text-tertiary)] mb-2 hover:text-[var(--text-secondary)] transition-colors"
-            >
-              {openSections.duchamp ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
-              Duchamp
-            </button>
-            {openSections.duchamp && (
-              <div className="ml-3 space-y-1">
-                <SidebarLink
-                  href="/rhonda-shearer"
-                  label="Rhonda Shearer"
-                  onNavigate={close}
-                />
-                <SidebarLink
-                  href="/readymades"
-                  label="The Readymades"
-                  onNavigate={close}
-                />
-                <SidebarLink
-                  href="/chess"
-                  label="Chess"
-                  onNavigate={close}
-                />
-                <SidebarLink
-                  href="/the-boxes"
-                  label="The Boxes"
-                  onNavigate={close}
-                />
-                <div className="ml-3 space-y-1">
-                  <SidebarLink
-                    href="/the-boxes#green-box"
-                    label="The Green Box (1934)"
-                    onNavigate={close}
-                  />
-                  <SidebarLink
-                    href="/the-boxes#white-box"
-                    label="The White Box (1967)"
-                    onNavigate={close}
-                  />
-                </div>
-              </div>
-            )}
-          </div>
-
-          {/* Critiques */}
-          <div>
-            <button
-              onClick={() => toggleSection('critiques')}
-              className="flex items-center gap-1 w-full text-left text-[0.7rem] uppercase tracking-[0.2em] text-[var(--text-tertiary)] mb-2 hover:text-[var(--text-secondary)] transition-colors"
-            >
-              {openSections.critiques ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
-              Critiques
-            </button>
-            {openSections.critiques && (
-              <div className="space-y-1">
-                {data.critiques.map((critique) => (
-                  <SidebarLink
-                    key={critique.slug}
-                    href={`/critiques/${critique.slug}`}
-                    label={critique.title}
-                    onNavigate={close}
-                  />
-                ))}
-              </div>
-            )}
-          </div>
-
-          {/* Author */}
-          <div>
-            <button
-              onClick={() => toggleSection('author')}
-              className="flex items-center gap-1 w-full text-left text-[0.7rem] uppercase tracking-[0.2em] text-[var(--text-tertiary)] mb-2 hover:text-[var(--text-secondary)] transition-colors"
-            >
-              {openSections.author ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
-              Author
-            </button>
-            {openSections.author && (
-              <SidebarLink
-                href="/about"
-                label={data.about.title}
-                onNavigate={close}
-              />
-            )}
-          </div>
-
-        </div>
+        <NavigationMenu navigation={navigation} onNavigate={() => setOpen(false)} className="mt-6" />
       </SheetContent>
     </Sheet>
   );
-}
-
-/**
- * Formats an ISO date string as a short month/day label (e.g. "Apr 11").
- * Parses the date components directly to avoid timezone offset bugs that
- * would otherwise cause a UTC-midnight date to display as the prior day.
- */
-function formatShortDate(iso: string): string {
-  const dateOnly = iso.split('T')[0];
-  const [, monthStr, dayStr] = dateOnly.split('-');
-  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-  const monthIndex = Number(monthStr) - 1;
-  const day = Number(dayStr);
-  return `${months[monthIndex] ?? ''} ${day}`;
 }

--- a/components/site/navigation-menu.tsx
+++ b/components/site/navigation-menu.tsx
@@ -1,0 +1,241 @@
+'use client';
+
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { usePathname } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+import { cn } from '@/lib/utils';
+import { SidebarLink } from './sidebar-link';
+import type { NavGroupItem, NavItem, NavSectionItem, SiteNavigation } from './site-navigation';
+
+interface NavigationMenuProps {
+  navigation: SiteNavigation;
+  onNavigate?: () => void;
+  className?: string;
+}
+
+/**
+ * Shared recursive navigation renderer used by both the desktop sidebar and
+ * the mobile sheet drawer.
+ */
+export function NavigationMenu({ navigation, onNavigate, className }: NavigationMenuProps) {
+  const pathname = usePathname();
+  const [openSections, setOpenSections] = useState<Record<string, boolean>>(() =>
+    collectOpenSections(navigation.secondary, pathname)
+  );
+
+  useEffect(() => {
+    const activeSections = collectOpenSections(navigation.secondary, pathname);
+    setOpenSections((previous) => ({ ...previous, ...activeSections }));
+  }, [pathname]);
+
+  const toggleSection = (sectionId: string) => {
+    setOpenSections((previous) => ({
+      ...previous,
+      [sectionId]: !previous[sectionId],
+    }));
+  };
+
+  return (
+    <div className={cn('space-y-6', className)}>
+      <div className="space-y-2 border-b border-[var(--border-subtle)] pb-4">
+        {navigation.primary.map((link) => (
+          <SidebarLink
+            key={link.href}
+            href={link.href}
+            label={link.label}
+            meta={link.meta}
+            external={link.external}
+            onNavigate={onNavigate}
+          />
+        ))}
+      </div>
+
+      <div>
+        <p className="text-[0.7rem] uppercase tracking-[0.25em] text-[var(--accent-gold)]">
+          {navigation.secondaryLabel}
+        </p>
+      </div>
+
+      {renderItems({
+        items: navigation.secondary,
+        onNavigate,
+        onToggleSection: toggleSection,
+        openSections,
+      })}
+    </div>
+  );
+}
+
+function renderItems({
+  items,
+  onNavigate,
+  onToggleSection,
+  openSections,
+  level = 0,
+}: {
+  items: NavItem[];
+  onNavigate?: () => void;
+  onToggleSection: (sectionId: string) => void;
+  openSections: Record<string, boolean>;
+  level?: number;
+}) {
+  return (
+    <div className={cn('space-y-3', level > 0 && 'ml-3 border-l border-[var(--border-subtle)] pl-3')}>
+      {items.map((item) => {
+        if (item.type === 'link') {
+          return (
+            <SidebarLink
+              key={item.href}
+              href={item.href}
+              label={item.label}
+              meta={item.meta}
+              external={item.external}
+              onNavigate={onNavigate}
+            />
+          );
+        }
+
+        if (item.type === 'group') {
+          return (
+            <NavigationGroup
+              key={`${level}-group-${item.children.map(getItemKey).join('-')}`}
+              item={item}
+              level={level}
+              onNavigate={onNavigate}
+              onToggleSection={onToggleSection}
+              openSections={openSections}
+            />
+          );
+        }
+
+        return (
+          <NavigationSection
+            key={item.id}
+            item={item}
+            level={level}
+            onNavigate={onNavigate}
+            onToggleSection={onToggleSection}
+            openSections={openSections}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+function NavigationGroup({
+  item,
+  level,
+  onNavigate,
+  onToggleSection,
+  openSections,
+}: {
+  item: NavGroupItem;
+  level: number;
+  onNavigate?: () => void;
+  onToggleSection: (sectionId: string) => void;
+  openSections: Record<string, boolean>;
+}) {
+  return renderItems({
+    items: item.children,
+    onNavigate,
+    onToggleSection,
+    openSections,
+    level: level + 1,
+  });
+}
+
+function NavigationSection({
+  item,
+  level,
+  onNavigate,
+  onToggleSection,
+  openSections,
+}: {
+  item: NavSectionItem;
+  level: number;
+  onNavigate?: () => void;
+  onToggleSection: (sectionId: string) => void;
+  openSections: Record<string, boolean>;
+}) {
+  const isOpen = !!openSections[item.id];
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => onToggleSection(item.id)}
+        aria-expanded={isOpen}
+        className="mb-2 flex w-full items-center gap-1 text-left text-[0.7rem] uppercase tracking-[0.2em] text-[var(--text-tertiary)] transition-colors hover:text-[var(--text-secondary)]"
+      >
+        {isOpen ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+        <span>{item.label}</span>
+      </button>
+
+      {isOpen && (
+        <>
+          {item.children.length ? (
+            renderItems({
+              items: item.children,
+              onNavigate,
+              onToggleSection,
+              openSections,
+              level: level + 1,
+            })
+          ) : item.emptyLabel ? (
+            <p className="ml-3 text-sm text-[var(--text-tertiary)]">{item.emptyLabel}</p>
+          ) : null}
+        </>
+      )}
+    </div>
+  );
+}
+
+function collectOpenSections(items: NavItem[], pathname: string): Record<string, boolean> {
+  return items.reduce<Record<string, boolean>>((accumulator, item) => {
+    if (item.type === 'link') {
+      return accumulator;
+    }
+
+    if (item.type === 'group') {
+      return {
+        ...accumulator,
+        ...collectOpenSections(item.children, pathname),
+      };
+    }
+
+    const childSections = collectOpenSections(item.children, pathname);
+    const shouldOpen = item.children.some((child) => itemMatchesPath(child, pathname));
+
+    return {
+      ...accumulator,
+      ...childSections,
+      [item.id]: shouldOpen,
+    };
+  }, {});
+}
+
+function itemMatchesPath(item: NavItem, pathname: string): boolean {
+  if (item.type === 'link') {
+    return !item.external && item.href.split('#')[0] === pathname;
+  }
+
+  if (item.type === 'group') {
+    return item.children.some((child) => itemMatchesPath(child, pathname));
+  }
+
+  return item.children.some((child) => itemMatchesPath(child, pathname));
+}
+
+function getItemKey(item: NavItem): string {
+  if (item.type === 'link') {
+    return item.href;
+  }
+
+  if (item.type === 'section') {
+    return item.id;
+  }
+
+  return item.children.map(getItemKey).join('-');
+}

--- a/components/site/sidebar-link.tsx
+++ b/components/site/sidebar-link.tsx
@@ -26,6 +26,7 @@ export function SidebarLink({ href, label, icon, meta, onNavigate, external }: S
         href={href}
         target="_blank"
         rel="noopener noreferrer"
+        onClick={onNavigate}
         className="sidebar-link border-l-4 border-transparent"
       >
         {icon}

--- a/components/site/sidebar.tsx
+++ b/components/site/sidebar.tsx
@@ -1,369 +1,47 @@
 'use client';
 
-import Link from 'next/link';
 import Image from 'next/image';
-import { ChevronDown, ChevronRight } from 'lucide-react';
-import { useState } from 'react';
+import Link from 'next/link';
+import { useMemo } from 'react';
 
 import type { SidebarData } from '@/lib/content';
-import { SidebarLink } from './sidebar-link';
 import { GlobalSearch } from './global-search';
+import { NavigationMenu } from './navigation-menu';
+import { getSiteNavigation } from './site-navigation';
 
 interface SidebarProps {
   data: SidebarData;
 }
 
 export function Sidebar({ data }: SidebarProps) {
-  const [openSections, setOpenSections] = useState({
-    scratchWritings: false,
-    xenotextTheory: false,
-    cosmology: false,
-    pataphysics: false,
-    bachelorMachines: false,
-    duchamp: false,
-    critiques: false,
-    author: false,
-  });
-
-  const toggleSection = (section: keyof typeof openSections) => {
-    setOpenSections(prev => ({ ...prev, [section]: !prev[section] }));
-  };
-
-  const livingThesisDateLabel = formatShortDate(data.livingThesis.updated);
+  const navigation = useMemo(() => getSiteNavigation(data), [data]);
 
   return (
-    <aside className="hidden lg:flex fixed top-0 bottom-0 left-0 w-[280px] flex-col border-r border-[var(--border-subtle)] bg-[var(--bg-secondary)] z-[70] overflow-y-auto pt-safe">
-      {/* Header Section */}
-      <div className="flex-shrink-0 sticky top-0 bg-[var(--bg-secondary)]">
-        <Link href="/" className="border-b border-[var(--border-subtle)] p-3 flex items-center gap-3">
+    <aside className="fixed bottom-0 left-0 top-0 z-[70] hidden w-[280px] flex-col overflow-hidden border-r border-[var(--border-subtle)] bg-[var(--bg-secondary)] pt-safe lg:flex">
+      <div className="sticky top-0 flex-shrink-0 bg-[var(--bg-secondary)]">
+        <Link href="/" className="flex items-center gap-3 border-b border-[var(--border-subtle)] p-3">
           <Image
             src="/images/dashusnavnulsigil.png"
             alt="DashusNavnul Sigil"
             width={48}
             height={48}
-            className="opacity-90 flex-shrink-0"
+            className="flex-shrink-0 opacity-90"
           />
-          <span className="font-mono font-bold text-white text-base leading-none whitespace-nowrap">
+          <span className="font-mono text-base font-bold leading-none text-white whitespace-nowrap">
             ~dashus-navnul
           </span>
         </Link>
 
-        {/* Search */}
         <div className="border-b border-[var(--border-subtle)] p-4">
           <GlobalSearch variant="sidebar" />
         </div>
-
-        {/* Primary Navigation - Home, Living Thesis, Master List, TL;DR, Initial Thesis */}
-        <div className="border-b border-[var(--border-subtle)] p-4 space-y-2">
-          <SidebarLink
-            href="/"
-            label="Home Page"
-          />
-          <SidebarLink
-            href="/living-thesis"
-            label="Living Thesis"
-            meta={livingThesisDateLabel}
-          />
-          <SidebarLink
-            href="/master-list"
-            label="Master List"
-            meta={`${data.masterList.count} correspondences`}
-          />
-          <SidebarLink
-            href="/tldr"
-            label="TL;DR"
-            meta="Bitcoin"
-          />
-          <SidebarLink
-            href="/initial-thesis"
-            label="Initial Thesis"
-            meta="Ethereum"
-          />
-        </div>
       </div>
 
-      {/* Scrollable Navigation Section - Errata */}
-      <div className="flex-1 overflow-y-auto scrollbar-thin">
-        <nav className="space-y-6 px-4 py-6">
-          {/* Errata header */}
-          <div>
-            <p className="text-[0.7rem] uppercase tracking-[0.25em] text-[var(--accent-gold)]">Errata</p>
-          </div>
-
-          {/* Elden Ring Item Cards — direct link */}
-          <SidebarLink
-            href="/gatherer"
-            label="Elden Ring Item Cards"
-          />
-
-          {/* Scratch Writings */}
-          <div>
-            <button
-              onClick={() => toggleSection('scratchWritings')}
-              className="flex items-center gap-1 w-full text-left text-[0.7rem] uppercase tracking-[0.2em] text-[var(--text-tertiary)] mb-2 hover:text-[var(--text-secondary)] transition-colors"
-            >
-              {openSections.scratchWritings ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
-              Scratch Writings
-            </button>
-            {openSections.scratchWritings && (
-              <div className="space-y-1">
-                <SidebarLink
-                  href="/belevan"
-                  label="Belevan, Mónica"
-                />
-                <SidebarLink
-                  href="/large-glass-breakdown"
-                  label="Selected Quotes on the Large Glass"
-                />
-                <SidebarLink
-                  href="/duchamp-biography"
-                  label="Duchamp Biography"
-                />
-                <SidebarLink
-                  href="/endings"
-                  label="Endings as Post-War Japan"
-                />
-                <SidebarLink
-                  href="/golden-bough"
-                  label="The Golden Bough"
-                />
-                <SidebarLink
-                  href="/bibliography"
-                  label="Bibliography & Resources"
-                />
-              </div>
-            )}
-          </div>
-
-          {/* Pataphysics */}
-          <div>
-            <button
-              onClick={() => toggleSection('pataphysics')}
-              className="flex items-center gap-1 w-full text-left text-[0.7rem] uppercase tracking-[0.2em] text-[var(--text-tertiary)] mb-2 hover:text-[var(--text-secondary)] transition-colors"
-            >
-              {openSections.pataphysics ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
-              Pataphysics
-            </button>
-            {openSections.pataphysics && (
-              <div className="space-y-1">
-                <SidebarLink
-                  href="/pataphysics"
-                  label="Understand Pataphysics"
-                />
-                <SidebarLink
-                  href="/pataphysics/pataphysics-engine"
-                  label="A 'Pataphysics Engine"
-                />
-                <SidebarLink
-                  href="/what-is-pataphysics"
-                  label="What is Pataphysics?"
-                />
-                <SidebarLink
-                  href="/vocab"
-                  label="Pataphysics Vocabulary"
-                />
-              </div>
-            )}
-          </div>
-
-          {/* The Xenotext Theory */}
-          <div>
-            <button
-              onClick={() => toggleSection('xenotextTheory')}
-              className="flex items-center gap-1 w-full text-left text-[0.7rem] uppercase tracking-[0.2em] text-[var(--text-tertiary)] mb-2 hover:text-[var(--text-secondary)] transition-colors"
-            >
-              {openSections.xenotextTheory ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
-              The Xenotext Theory
-            </button>
-            {openSections.xenotextTheory && (
-              <div className="space-y-1">
-                <SidebarLink
-                  href="/xenotext"
-                  label="Xenotext Cipher"
-                  meta="Interactive"
-                />
-                <SidebarLink
-                  href="/xenotext-theory"
-                  label="The Xenotext Theory"
-                />
-                <div className="ml-3 space-y-1">
-                  <SidebarLink
-                    href="/xenotext-theory#uncontrollable-meaning"
-                    label="Uncontrollable Meaning"
-                  />
-                  <SidebarLink
-                    href="/xenotext-theory#flower-crucible-erdtree"
-                    label="Flower Crucible & Erdtree"
-                  />
-                  <SidebarLink
-                    href="/xenotext-theory#flower-maidens"
-                    label="Flower Maidens"
-                  />
-                </div>
-              </div>
-            )}
-          </div>
-
-          {/* Cosmology */}
-          <div>
-            <button
-              onClick={() => toggleSection('cosmology')}
-              className="flex items-center gap-1 w-full text-left text-[0.7rem] uppercase tracking-[0.2em] text-[var(--text-tertiary)] mb-2 hover:text-[var(--text-secondary)] transition-colors"
-            >
-              {openSections.cosmology ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
-              Cosmology
-            </button>
-            {openSections.cosmology && (
-              <div className="ml-3 space-y-1">
-                <SidebarLink
-                  href="/daisugi-cosmology"
-                  label="The Daisugi Tree"
-                />
-                <SidebarLink
-                  href="/astrology"
-                  label="Elden Ring's Astrology"
-                />
-              </div>
-            )}
-          </div>
-
-          {/* Bachelor Machines */}
-          <div>
-            <button
-              onClick={() => toggleSection('bachelorMachines')}
-              className="flex items-center gap-1 w-full text-left text-[0.7rem] uppercase tracking-[0.2em] text-[var(--text-tertiary)] mb-2 hover:text-[var(--text-secondary)] transition-colors"
-            >
-              {openSections.bachelorMachines ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
-              Bachelor Machines
-            </button>
-            {openSections.bachelorMachines && (
-              <div className="ml-3 space-y-1">
-                <SidebarLink
-                  href="/bachelor-machines"
-                  label="Understanding Bachelor Machines"
-                />
-                <SidebarLink
-                  href="/chocolate-grinder"
-                  label="The Chocolate Grinder"
-                />
-                <SidebarLink
-                  href="/bachelor-machines/terms"
-                  label="Catalog & Vocabulary"
-                />
-                <SidebarLink
-                  href="https://www.eurogamer.net/an-obituary-for-the-architecture-of-dark-souls-eternally-dying-land"
-                  label="Eternally Dying Land"
-                  external
-                />
-              </div>
-            )}
-          </div>
-
-          {/* Duchamp */}
-          <div>
-            <button
-              onClick={() => toggleSection('duchamp')}
-              className="flex items-center gap-1 w-full text-left text-[0.7rem] uppercase tracking-[0.2em] text-[var(--text-tertiary)] mb-2 hover:text-[var(--text-secondary)] transition-colors"
-            >
-              {openSections.duchamp ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
-              Duchamp
-            </button>
-            {openSections.duchamp && (
-              <div className="ml-3 space-y-1">
-                <SidebarLink
-                  href="/rhonda-shearer"
-                  label="Rhonda Shearer"
-                />
-                <div className="ml-3 space-y-1">
-                  <SidebarLink
-                    href="/impossible-bed"
-                    label="The Impossible Bed"
-                  />
-                </div>
-                <SidebarLink
-                  href="/readymades"
-                  label="The Readymades"
-                />
-                <SidebarLink
-                  href="/chess"
-                  label="Chess"
-                />
-                <SidebarLink
-                  href="/the-boxes"
-                  label="The Boxes"
-                />
-                <div className="ml-3 space-y-1">
-                  <SidebarLink
-                    href="/the-boxes#green-box"
-                    label="The Green Box (1934)"
-                  />
-                  <SidebarLink
-                    href="/the-boxes#white-box"
-                    label="The White Box (1967)"
-                  />
-                </div>
-              </div>
-            )}
-          </div>
-
-          {/* Critiques */}
-          <div>
-            <button
-              onClick={() => toggleSection('critiques')}
-              className="flex items-center gap-1 w-full text-left text-[0.7rem] uppercase tracking-[0.2em] text-[var(--text-tertiary)] mb-2 hover:text-[var(--text-secondary)] transition-colors"
-            >
-              {openSections.critiques ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
-              Critiques
-            </button>
-            {openSections.critiques && (
-              <div className="space-y-1">
-                {data.critiques.map((critique) => (
-                  <SidebarLink
-                    key={critique.slug}
-                    href={`/critiques/${critique.slug}`}
-                    label={critique.title}
-                  />
-                ))}
-                {!data.critiques.length && (
-                  <p className="px-3 text-sm text-[var(--text-tertiary)]">No critiques yet.</p>
-                )}
-              </div>
-            )}
-          </div>
-
-          {/* Author */}
-          <div>
-            <button
-              onClick={() => toggleSection('author')}
-              className="flex items-center gap-1 w-full text-left text-[0.7rem] uppercase tracking-[0.2em] text-[var(--text-tertiary)] mb-2 hover:text-[var(--text-secondary)] transition-colors"
-            >
-              {openSections.author ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
-              Author
-            </button>
-            {openSections.author && (
-              <SidebarLink
-                href="/about"
-                label={data.about.title}
-              />
-            )}
-          </div>
-
+      <div className="scrollbar-thin flex-1 overflow-y-auto">
+        <nav className="px-4 py-6">
+          <NavigationMenu navigation={navigation} />
         </nav>
       </div>
     </aside>
   );
-}
-
-/**
- * Formats an ISO date string as a short month/day label (e.g. "Apr 11").
- * Parses the date components directly to avoid timezone offset bugs that
- * would otherwise cause a UTC-midnight date to display as the prior day.
- */
-function formatShortDate(iso: string): string {
-  const dateOnly = iso.split('T')[0];
-  const [, monthStr, dayStr] = dateOnly.split('-');
-  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-  const monthIndex = Number(monthStr) - 1;
-  const day = Number(dayStr);
-  return `${months[monthIndex] ?? ''} ${day}`;
 }

--- a/components/site/site-navigation.ts
+++ b/components/site/site-navigation.ts
@@ -1,0 +1,180 @@
+import type { SidebarData } from '@/lib/content';
+
+export type NavLinkItem = {
+  type: 'link';
+  href: string;
+  label: string;
+  meta?: string;
+  external?: boolean;
+};
+
+export type NavSectionItem = {
+  type: 'section';
+  id: string;
+  label: string;
+  children: NavItem[];
+  emptyLabel?: string;
+};
+
+export type NavGroupItem = {
+  type: 'group';
+  children: NavItem[];
+};
+
+export type NavItem = NavLinkItem | NavSectionItem | NavGroupItem;
+
+export type SiteNavigation = {
+  primary: NavLinkItem[];
+  secondaryLabel: string;
+  secondary: NavItem[];
+};
+
+/**
+ * Builds the site navigation tree once so desktop and mobile menus stay in
+ * lockstep instead of drifting apart.
+ */
+export function getSiteNavigation(data: SidebarData): SiteNavigation {
+  return {
+    primary: [
+      { type: 'link', href: '/', label: 'Home Page' },
+      {
+        type: 'link',
+        href: '/living-thesis',
+        label: 'Living Thesis',
+        meta: formatShortDate(data.livingThesis.updated),
+      },
+      {
+        type: 'link',
+        href: '/master-list',
+        label: 'Master List',
+        meta: `${data.masterList.count} correspondences`,
+      },
+      { type: 'link', href: '/tldr', label: 'TL;DR', meta: 'Bitcoin' },
+      { type: 'link', href: '/initial-thesis', label: 'Initial Thesis', meta: 'Ethereum' },
+    ],
+    secondaryLabel: 'Errata',
+    secondary: [
+      { type: 'link', href: '/gatherer', label: 'Elden Ring Item Cards' },
+      {
+        type: 'section',
+        id: 'scratch-writings',
+        label: 'Scratch Writings',
+        children: [
+          { type: 'link', href: '/belevan', label: 'Belevan, Mónica' },
+          { type: 'link', href: '/large-glass-breakdown', label: 'Selected Quotes on the Large Glass' },
+          { type: 'link', href: '/duchamp-biography', label: 'Duchamp Biography' },
+          { type: 'link', href: '/endings', label: 'Endings as Post-War Japan' },
+          { type: 'link', href: '/golden-bough', label: 'The Golden Bough' },
+          { type: 'link', href: '/bibliography', label: 'Bibliography & Resources' },
+        ],
+      },
+      {
+        type: 'section',
+        id: 'pataphysics',
+        label: 'Pataphysics',
+        children: [
+          { type: 'link', href: '/bachelor-machines', label: 'Understanding Bachelor Machines' },
+          { type: 'link', href: '/pataphysics', label: 'Understand Pataphysics' },
+          { type: 'link', href: '/pataphysics/pataphysics-engine', label: "A 'Pataphysics Engine" },
+          { type: 'link', href: '/what-is-pataphysics', label: 'What is Pataphysics?' },
+          { type: 'link', href: '/vocab', label: 'Pataphysics Vocabulary' },
+        ],
+      },
+      {
+        type: 'section',
+        id: 'xenotext-theory',
+        label: 'The Xenotext Theory',
+        children: [
+          { type: 'link', href: '/xenotext', label: 'Xenotext Cipher', meta: 'Interactive' },
+          { type: 'link', href: '/xenotext-theory', label: 'The Xenotext Theory' },
+          {
+            type: 'group',
+            children: [
+              { type: 'link', href: '/xenotext-theory#uncontrollable-meaning', label: 'Uncontrollable Meaning' },
+              { type: 'link', href: '/xenotext-theory#flower-crucible-erdtree', label: 'Flower Crucible & Erdtree' },
+              { type: 'link', href: '/xenotext-theory#flower-maidens', label: 'Flower Maidens' },
+            ],
+          },
+        ],
+      },
+      {
+        type: 'section',
+        id: 'cosmology',
+        label: 'Cosmology',
+        children: [
+          { type: 'link', href: '/daisugi-cosmology', label: 'The Daisugi Tree' },
+          { type: 'link', href: '/astrology', label: "Elden Ring's Astrology" },
+        ],
+      },
+      {
+        type: 'section',
+        id: 'bachelor-machines',
+        label: 'Bachelor Machines',
+        children: [
+          { type: 'link', href: '/bachelor-machines', label: 'Understanding Bachelor Machines' },
+          { type: 'link', href: '/chocolate-grinder', label: 'The Chocolate Grinder' },
+          { type: 'link', href: '/bachelor-machines/terms', label: 'Catalog & Vocabulary' },
+          {
+            type: 'link',
+            href: 'https://www.eurogamer.net/an-obituary-for-the-architecture-of-dark-souls-eternally-dying-land',
+            label: 'Eternally Dying Land',
+            external: true,
+          },
+        ],
+      },
+      {
+        type: 'section',
+        id: 'duchamp',
+        label: 'Duchamp',
+        children: [
+          { type: 'link', href: '/rhonda-shearer', label: 'Rhonda Shearer' },
+          {
+            type: 'group',
+            children: [{ type: 'link', href: '/impossible-bed', label: 'The Impossible Bed' }],
+          },
+          { type: 'link', href: '/readymades', label: 'The Readymades' },
+          { type: 'link', href: '/chess', label: 'Chess' },
+          { type: 'link', href: '/the-boxes', label: 'The Boxes' },
+          {
+            type: 'group',
+            children: [
+              { type: 'link', href: '/the-boxes#green-box', label: 'The Green Box (1934)' },
+              { type: 'link', href: '/the-boxes#white-box', label: 'The White Box (1967)' },
+            ],
+          },
+        ],
+      },
+      {
+        type: 'section',
+        id: 'critiques',
+        label: 'Critiques',
+        children: data.critiques.map((critique) => ({
+          type: 'link' as const,
+          href: `/critiques/${critique.slug}`,
+          label: critique.title,
+        })),
+        emptyLabel: 'No critiques yet.',
+      },
+      {
+        type: 'section',
+        id: 'author',
+        label: 'Author',
+        children: [{ type: 'link', href: '/about', label: data.about.title }],
+      },
+    ],
+  };
+}
+
+/**
+ * Formats an ISO date string as a short month/day label (e.g. "Apr 11").
+ * Parses the date components directly to avoid timezone offset bugs that
+ * would otherwise cause a UTC-midnight date to display as the prior day.
+ */
+function formatShortDate(iso: string): string {
+  const dateOnly = iso.split('T')[0];
+  const [, monthStr, dayStr] = dateOnly.split('-');
+  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+  const monthIndex = Number(monthStr) - 1;
+  const day = Number(dayStr);
+  return `${months[monthIndex] ?? ''} ${day}`;
+}

--- a/components/site/top-bar.tsx
+++ b/components/site/top-bar.tsx
@@ -11,11 +11,11 @@ interface TopBarProps {
 
 export function TopBar({ data }: TopBarProps) {
   return (
-    <header className="border-b border-[var(--border-subtle)] bg-[var(--bg-secondary)] px-4 py-4 lg:py-6 relative z-[60]">
+    <header className="relative z-[40] border-b border-[var(--border-subtle)] bg-[var(--bg-secondary)] px-4 py-4 lg:py-6">
       {/* Desktop: Title with actions */}
       <div className="hidden lg:block">
         <div className="flex items-center justify-between gap-4">
-          <MobileSidebar data={data} />
+          <div className="w-12" aria-hidden="true" />
           <Link href="/" className="flex-1 text-center">
             <span className="text-3xl xl:text-4xl font-serif text-[var(--accent-gold)] leading-tight">
               Elden Ring is Marcel Duchamp&apos;s The Bride Stripped Bare by her Bachelors, Even
@@ -33,7 +33,7 @@ export function TopBar({ data }: TopBarProps) {
             <MobileSidebar data={data} />
           </div>
           <div className="flex-1 flex flex-col justify-end gap-1">
-            <div className="font-mono font-bold text-white text-2xl leading-none whitespace-nowrap">
+            <div className="font-mono font-bold text-white text-xl leading-none whitespace-nowrap">
               ~dashus-navnul
             </div>
             <Link
@@ -47,7 +47,7 @@ export function TopBar({ data }: TopBarProps) {
         </div>
 
         {/* Title */}
-        <Link href="/" className="block font-serif text-[var(--accent-gold)] leading-tight text-center text-4xl pb-2 text-4xl">
+        <Link href="/" className="block pb-2 text-center font-serif text-3xl leading-tight text-[var(--accent-gold)]">
           Elden Ring Is Marcel Duchamp&apos;s <em>The Bride Stripped Bare By Her Bachelors, Even</em>
         </Link>
       </div>

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -18,7 +18,7 @@ const SheetOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Overlay
     className={cn(
-      'fixed inset-0 z-50 bg-[rgba(0,0,0,0.7)] backdrop-blur-sm transition-opacity',
+      'fixed inset-0 z-[90] bg-[rgba(0,0,0,0.78)] backdrop-blur-sm',
       className
     )}
     {...props}
@@ -36,18 +36,17 @@ const SheetContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed inset-y-0 left-0 z-50 w-80 max-w-[85vw] border-r border-[var(--border-subtle)] bg-[var(--bg-secondary)] shadow-panel flex flex-col transition-transform',
+        'fixed left-0 top-0 z-[100] flex h-[100dvh] max-h-[100dvh] w-80 max-w-[85vw] flex-col overflow-hidden border-r border-[var(--border-subtle)] bg-[var(--bg-secondary)] shadow-panel outline-none',
         className
       )}
       {...props}
     >
-      {/* Close button - fixed at top */}
-      <DialogPrimitive.Close className="absolute right-4 top-4 z-10 rounded-full bg-[rgb(var(--bg-primary-rgb)/0.4)] p-1 text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors">
+      {/* Keep the close affordance inside the safe area so it stays tappable on mobile browsers. */}
+      <DialogPrimitive.Close className="absolute right-4 top-[max(1rem,env(safe-area-inset-top,0px))] z-10 rounded-full bg-[rgb(var(--bg-primary-rgb)/0.55)] p-1.5 text-[var(--text-secondary)] transition-colors hover:text-[var(--text-primary)]">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>
-      {/* Scrollable content area */}
-      <div className="flex-1 overflow-y-auto p-6 pb-8">
+      <div className="flex-1 overflow-y-auto overscroll-contain px-4 pb-[max(1.5rem,env(safe-area-inset-bottom,0px))] pt-[max(1.25rem,env(safe-area-inset-top,0px)+1.25rem)]">
         {children}
       </div>
     </DialogPrimitive.Content>


### PR DESCRIPTION
## What
This PR promotes the tested `dev` branch to `main`, carrying the rebuilt shared site navigation, the repaired mobile drawer behavior, and the tightened mobile header and article hero typography into production.

## Why
The mobile menu regression was fixed and reviewed in the test environment, and the associated mobile typography adjustments are ready to ship from `dev` to `main`.

## Changes
- Promote shared desktop/mobile navigation
- Ship mobile drawer layering fix
- Ship mobile trigger refinement
- Reduce mobile top-bar title scale
- Reduce article hero title scale
- Tighten mobile hero meta sizing

## Testing
- Reviewed in test environment
- `./node_modules/.bin/tsc --noEmit`
- `NEXT_TELEMETRY_DISABLED=1 npm run build`
- Build still reports the repos existing Next warnings about `request.url` static generation and page deopt notices
