### PR TITLE
docs: align repository guidance for agents and reviewers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,332 @@
+# Elden Glass Agent Guide
+
+This file is for agents and collaborators working in this repository.
+
+Read it before making changes.
+
+## Non-Negotiables
+
+### We Do Not Commit Directly To `main`
+
+Do not commit directly to `main`.
+
+Do not push directly to `main`.
+
+Do not "just make a quick fix on production."
+
+All work happens on a branch. That branch opens a PR into `dev`. After `dev` is reviewed and validated online, we open a second PR from `dev` into `main`.
+
+This is the required flow:
+
+1. Branch off `dev`
+2. Make the change
+3. Run local verification
+4. Push the branch
+5. Open a PR to `dev`
+6. Request review
+7. Merge to `dev`
+8. Validate the deployed `dev` build online
+9. Open a PR from `dev` to `main`
+10. Request review
+11. Merge `dev` to `main`
+
+If you are tempted to skip this flow, do not.
+
+### Request Review
+
+Every meaningful change should go through a pull request and review.
+
+Do not self-authorize a direct production change because it "looks small." The mobile nav fix, Gatherer route fix, and similar changes all look small until deployment behavior proves otherwise.
+
+Do not treat docs-only changes as exempt from review. Docs can encode the operating procedure for the repository, so they also need PRs and review.
+
+### Content Belongs In MDX, Not Hardcoded JSX
+
+This site has a content pipeline. Use it.
+
+If the user wants to change article copy, section headings, thesis text, bibliography text, vocabulary entries, critique copy, or other authored content, edit the `.mdx` files in `content/`.
+
+Do not hardcode prose into TypeScript just because it is faster in the moment.
+
+Do not move content out of MDX and into JSX unless the user explicitly asks for that architectural change.
+
+If a page already reads from Contentlayer and `MarkdownRenderer`, keep using that path.
+
+TypeScript should define:
+
+- layout
+- shell/chrome
+- rendering components
+- interactive behavior
+- content interpretation
+
+TypeScript should not become a dumping ground for editorial content.
+
+## Site Structure
+
+### App Router
+
+This is a Next.js App Router site.
+
+- `app/layout.tsx` defines root metadata, global CSS, and root document structure.
+- `app/(site)/layout.tsx` wraps site pages with the shared shell and title-card provider.
+- `app/(site)/**/page.tsx` contains route entrypoints for site pages.
+- `app/api/**/route.ts` contains API endpoints used by search, title cards, and related features.
+
+### Shared Site Chrome
+
+The shared shell lives in `components/site/`.
+
+Important files:
+
+- `components/site/site-shell.tsx` composes the main site layout
+- `components/site/sidebar.tsx` renders the desktop sidebar
+- `components/site/mobile-sidebar.tsx` renders the mobile navigation drawer
+- `components/site/top-bar.tsx` renders the top header
+- `components/site/site-navigation.ts` defines the shared navigation tree
+- `components/site/navigation-menu.tsx` renders the shared nav structure
+
+If you need to change navigation, do it in the shared navigation system. Do not create separate desktop/mobile nav trees again.
+
+### Content Pipeline
+
+The site content is primarily driven by `content/` plus Contentlayer.
+
+Important files:
+
+- `contentlayer.config.ts` defines the document types and MDX pipeline
+- `lib/content.ts` is the content access layer used by route pages
+- `components/mdx/markdown-renderer.tsx` renders MDX using the registered custom components
+- `content/*.mdx` contains the longform authored documents
+- `content/vocab/*.mdx` contains vocabulary/catalog content
+- `content/critiques/*.mdx` contains critique pages
+
+Typical pattern:
+
+1. A route page in `app/(site)/.../page.tsx` loads a document from `lib/content.ts`
+2. The page renders hero chrome and metadata
+3. The main body is rendered through `MarkdownRenderer`
+
+If a user asks to edit a document page, your first instinct should be to inspect the corresponding MDX file in `content/`.
+
+### Data-Driven Features
+
+Not everything in the site is MDX. Structured datasets live in `data/`.
+
+Important files:
+
+- `data/title-cards.json`
+- `data/title-cards-split/*.json`
+- `data/sense-index.json`
+- `data/xenotext-theories.json`
+
+Relevant APIs:
+
+- `app/api/title-cards/route.ts`
+- `app/api/title-cards/all/route.ts`
+- `app/api/title-cards/catalog/route.ts`
+- `app/api/title-cards/category/route.ts`
+- `app/api/search/route.ts`
+- `app/api/related-by-sense/route.ts`
+
+If the user is changing Gatherer/title-card data, update the data source or the scripts that generate/manage it. Do not fake data changes in the UI layer.
+
+### Scripts
+
+Repository scripts live in `scripts/`.
+
+Notable examples:
+
+- `scripts/sync-critique-assets.js`
+- `scripts/generate-fedwiki-gatherer.js`
+- `scripts/export-to-fedwiki.js`
+- `scripts/sync-from-fedwiki.js`
+
+If a workflow already exists as a script, use or update the script rather than reproducing the logic ad hoc in a component.
+
+## Authoring Rules
+
+### Prefer MDX Edits For Content Changes
+
+For these categories, edit MDX first:
+
+- thesis text
+- article text
+- bibliography text
+- vocabulary text
+- critique text
+- static explanatory sections
+- frontmatter-driven hero metadata
+
+Examples:
+
+- `/living-thesis` comes from `content/living-thesis.mdx`
+- `/tldr` comes from `content/tldr.mdx`
+- `/initial-thesis` comes from `content/initial-thesis.mdx`
+- `/about` comes from `content/about.mdx`
+- `/bibliography` comes from `content/bibliography.mdx`
+- `/master-list` comes from `content/master-list.mdx`
+- `/bachelor-machines/terms` comes from `content/vocab/bachelor-machines.mdx`
+- `/vocab` comes from `content/vocab/pataphysics.mdx`
+
+If you find yourself typing large paragraphs into a `.tsx` file, stop and reconsider.
+
+### Use The Interpreter We Already Have
+
+This repo already has an MDX interpreter/rendering path:
+
+- Contentlayer parses the documents
+- `lib/content.ts` loads them
+- `MarkdownRenderer` renders them
+- MDX components provide richer embedded elements when needed
+
+Use that system.
+
+Do not bypass it by hardcoding content into React components unless the work is genuinely presentational or interactive.
+
+### Use Agentation For Content Collaboration
+
+When working with an LLM on content changes, use Agentation on the running site whenever possible.
+
+Agentation is installed in this repo and is wired in development through `components/agentation-dev.tsx` and `app/layout.tsx`.
+
+Use it for:
+
+- reviewing editorial changes in context
+- selecting specific headings, paragraphs, hero text, and callouts
+- capturing page-level feedback from the user
+- iterating on MDX-backed content with visible, anchored annotations instead of vague prose instructions
+
+Preferred workflow for content work:
+
+1. Run the site locally
+2. Open the relevant page in the browser
+3. Use Agentation to annotate the exact content that should change
+4. Apply the edits in the underlying MDX or data source
+5. Re-check the page with the annotations in view
+
+If the requested work is primarily about copy, structure, or editorial presentation, do not rely only on abstract chat descriptions when Agentation can anchor the requested change directly on-page.
+
+Agentation is a collaboration aid, not the source of truth. The source of truth remains:
+
+- MDX in `content/`
+- structured data in `data/`
+- rendering logic in components and route files
+
+### When TypeScript Changes Are Appropriate
+
+Use TypeScript edits for:
+
+- new UI components
+- navigation/layout changes
+- interactive client behavior
+- API behavior
+- data loading and transformation
+- MDX component support
+- styling and responsive fixes
+
+Use MDX edits for:
+
+- copy
+- headings
+- lists
+- citations
+- editorial structure
+- vocabulary entries
+- article body content
+
+## Deployment Strategy
+
+### Branching And Promotion
+
+The deployment model is:
+
+- feature/fix branch -> PR to `dev`
+- `dev` validated online
+- PR from `dev` -> `main`
+- `main` becomes production
+
+`dev` is the integration branch.
+
+`main` is the production branch.
+
+Do not branch from stale local history. Fetch first, and branch from current `origin/dev`.
+
+### Vercel
+
+Vercel auto-deploys branches and pull requests to unique preview URLs.
+
+That means every pushed branch/PR can be reviewed online at its own Vercel deployment URL before merge.
+
+After merging to `dev`, Vercel deploys the updated `dev` state so it can be tested online as the staging/integration environment.
+
+After merging `dev` into `main`, Vercel deploys production.
+
+Production lives at:
+
+- `https://eldenringisthelargeglass.com`
+
+There is also a Vercel production alias:
+
+- `https://elden-glass.vercel.app`
+
+When someone says "test it online," that means:
+
+1. Use the PR preview URL for branch validation
+2. Use the deployed `dev` build after merge-to-`dev`
+3. Use the production domain only after `dev -> main` is merged
+
+### Deployment Discipline
+
+Do not merge to `main` because local build passed.
+
+Do not merge to `main` because the PR preview "basically looks right."
+
+Do not merge to `main` until the `dev` deployment has been checked online when the change affects runtime behavior, routing, responsive behavior, API behavior, or content rendering.
+
+## Practical Workflow
+
+Before changing files:
+
+1. Check `git status`
+2. Check the current branch
+3. Fetch `origin`
+4. Start from current `origin/dev`
+5. Create a branch for the change
+
+Before opening a PR:
+
+1. Run the strongest local verification available
+2. Make sure the working tree is clean
+3. Push the branch
+4. Open a PR to `dev`
+5. Write a clear PR body
+6. Request review
+
+Before promoting `dev` to `main`:
+
+1. Confirm the merged change works in the online `dev` deployment
+2. Open a dedicated `dev -> main` PR
+3. Request review
+4. Merge only after that review/validation step
+
+## Avoid These Mistakes
+
+- Do not commit directly to `main`
+- Do not push directly to `main`
+- Do not hardcode document content into `.tsx` files when an MDX source exists
+- Do not fork mobile and desktop navigation/content definitions unnecessarily
+- Do not patch production behavior without a PR because "it is only one line"
+- Do not assume deployment behavior matches local behavior without checking Vercel
+
+## If You Are Unsure
+
+If a requested change feels like content, inspect `content/` first.
+
+If a requested change feels like data, inspect `data/` and `app/api/` first.
+
+If a requested change feels like layout/navigation, inspect `components/site/` first.
+
+If a requested change affects production, assume the correct path is:
+
+branch -> PR -> `dev` -> online validation -> PR -> `main`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,164 @@
+# Elden Glass
+
+Thesis site: **Elden Ring Is Marcel Duchamp's _The Bride Stripped Bare by Her Bachelors, Even_.**
+
+Production: [eldenringisthelargeglass.com](https://eldenringisthelargeglass.com)
+
+## Git Workflow
+
+### WE DO NOT COMMIT DIRECTLY TO `main`. EVER.
+
+All work happens on feature branches. Changes reach `main` exclusively through pull requests with review.
+
+The workflow:
+
+1. **Create a branch** off current `dev`.
+2. **Do your work** on the branch. Commit early, commit often.
+3. **Open a PR** targeting `dev`. Request review.
+4. **Merge to `dev`** only after review approval.
+5. **Validate `dev` online** after merge when the change affects runtime behavior, routing, layout, API behavior, or content rendering.
+6. **Promote `dev` to `main`** via a separate PR when a release is ready. This PR also requires review.
+
+Never force-push to `main` or `dev`. Never bypass review.
+
+### Branch naming
+
+- Pebbles issues: `<issue-id>/<description>`
+- Otherwise: `<feat,fix,docs,chore>/<description>`
+
+### Deployment pipeline
+
+Vercel deploys automatically from `dalten-collective/elden-glass` on GitHub:
+
+| Branch | Environment | URL |
+|--------|-------------|-----|
+| `main` | Production | [eldenringisthelargeglass.com](https://eldenringisthelargeglass.com) |
+| `dev` | Integration / preview | Unique Vercel preview URL per push |
+| Any PR | Preview | Unique Vercel preview URL per PR |
+
+Every push to `dev` and every PR gets its own preview deployment at a unique Vercel URL. Use these to verify changes before merging.
+
+One environment variable is set in Vercel:
+- `NEXT_PUBLIC_BASE_URL` = `https://eldenringisthelargeglass.com`
+
+## Content Architecture
+
+### Content lives in MDX. Not in TypeScript. Not in JSX.
+
+All long-form content is in `content/` as MDX files processed by Contentlayer 0.3.4. The entire point of this architecture is that **the author edits MDX files and nothing else**. The site renders those files through a pipeline that handles formatting, components, and layout automatically.
+
+**Do not hardcode content into React components or page files.** If content needs to appear on the site, it goes in an MDX file under `content/`. The page file (`app/(site)/*/page.tsx`) should be a thin shell that fetches the content document and passes it to `MarkdownRenderer`.
+
+### How it works
+
+1. MDX files in `content/` have YAML frontmatter (title, dates, hashes, etc.)
+2. `contentlayer.config.ts` defines document types and their fields
+3. Contentlayer compiles MDX at build/dev time into importable modules
+4. `lib/content.ts` provides getter functions for each document type
+5. Page files call getters and render via `<MarkdownRenderer code={doc.body.code} />`
+
+### Document types (defined in `contentlayer.config.ts`)
+
+- **InitialThesisDoc** -- `content/initial-thesis.mdx`
+- **TldrDoc** -- `content/tldr.mdx`
+- **LivingThesisDoc** -- `content/living-thesis.mdx`
+- **Critique** -- `content/critiques/*.mdx`
+- **AboutDoc** -- `content/about.mdx`
+- **BibliographyDoc** -- `content/bibliography.mdx`
+- **MasterListDoc** -- `content/master-list.mdx`
+- **VocabDoc** -- `content/vocab/*.mdx` (bachelor-machines, pataphysics)
+
+### MDX components available in content files
+
+These are registered in `components/mdx/markdown-renderer.tsx` and can be used directly in any MDX file:
+
+- `<FloatImage>` -- Floating images within prose
+- `<ItemCard>` -- Elden Ring item cards
+- `<ArtworkCard>` -- Duchamp artwork cards
+- `<LinkPreview>` -- Hover-preview links
+- `<MagnifierImage>` -- Zoomable images
+- `<DefinitionItem term="..." definition="..." source="...">` -- Vocabulary definitions (used heavily in vocab pages)
+
+GFM markdown tables are also supported via `remark-gfm` (used for machine catalogs in bachelor-machines.mdx).
+
+## Stack
+
+- Next.js 13.5.6 (App Router)
+- Contentlayer 0.3.4 (MDX pipeline)
+- Tailwind CSS + @tailwindcss/typography
+- TypeScript
+- Vercel (deployment)
+
+## Project Structure
+
+```
+app/
+  (site)/               All content pages (37 routes)
+  api/                  Title card, search, and sense-index endpoints
+components/
+  mdx/                  MDX components (MarkdownRenderer, DefinitionItem, FloatImage, etc.)
+  site/                 Layout (sidebar, top bar, navigation)
+  title-cards/          Rollover display, detail modal, provider
+  verification/         Hash verification UI
+content/                MDX source files -- this is where content lives
+  vocab/                Vocabulary MDX (bachelor-machines, pataphysics)
+contentlayer.config.ts  Document type definitions and MDX plugin config
+data/                   Title cards JSON, sense index, xenotext theories
+lib/                    Content getters, search index, utilities
+public/
+  proofs/               Blockchain attestation proof files
+  images/               All site imagery
+  animations/           Large Glass component GIFs
+```
+
+## Local Development
+
+```bash
+npm install
+npm run dev        # starts on localhost:3000
+```
+
+The dev server runs Contentlayer on startup to compile MDX. First boot takes ~10s; subsequent hot reloads are fast.
+
+```bash
+npm run typecheck  # contentlayer build + tsc --noEmit
+npm run build      # production build (same as what Vercel runs)
+```
+
+Always run `npm run build` locally before pushing a PR to verify the build will pass on Vercel.
+
+## Agentation (AI Visual Feedback)
+
+This site has [agentation](https://www.agentation.com/) installed as a dev dependency. It provides a visual annotation layer that lets you click UI elements in the browser, attach feedback notes, and pipe structured context (CSS selectors, source file paths, React component hierarchy, computed styles) directly to an AI agent.
+
+### How it's wired up
+
+- `components/agentation-dev.tsx` renders the `<Agentation>` component pointed at `http://localhost:4747`
+- `app/layout.tsx` includes it **only in development** (`process.env.NODE_ENV === 'development'`)
+- It does not ship to production
+
+### Using it
+
+1. Run `npm run dev` to start the site
+2. The agentation toolbar appears in the bottom-right corner of the browser
+3. Hover over any element to see its name highlighted
+4. Click an element to annotate it with feedback
+5. Copy the formatted markdown output and paste it into Claude Code (or, with MCP enabled, the agent reads annotations directly)
+
+With MCP integration active, there is no copy-paste step -- the agent can read and act on annotations directly. You can say things like "address my feedback" or "fix annotation 3."
+
+When the requested work is primarily about copy, structure, or page-level presentation, prefer using Agentation on the running site to anchor the requested change before editing the underlying MDX or data source.
+
+### Setup for new developers
+
+If you're working on this site with an AI agent, install agentation and ensure the MCP server is running so the agent has direct access to your UI annotations. See [agentation.com](https://www.agentation.com/) for full setup instructions.
+
+## Title Cards
+
+Title cards (the rollover definitions throughout the site) are **view-only**. There are no edit affordances anywhere on the site. The card data lives in `data/title-cards.json` and `data/title-cards-split/`. The modal triggered by clicking a card's view button shows the full card detail but does not allow editing.
+
+## Vercel Configuration
+
+`vercel.json` handles headers (security, RSS content-type) and redirects (RSS aliases). The build runs in the `iad1` region. No custom functions or middleware beyond what Next.js provides.
+
+The site is on Vercel's Hobby plan. The repo at `dalten-collective/elden-glass` is public (required for Hobby plan org repos).

--- a/README.md
+++ b/README.md
@@ -1,51 +1,123 @@
-# eldengglass
+# Elden Glass
 
-`eldengglass` is a standalone Next.js site built from the Elden Ring / Large Glass website work originally developed inside `elden-ring-discovery`.
+**Elden Ring Is Marcel Duchamp's *The Bride Stripped Bare by Her Bachelors, Even*.**
 
-This repo now carries the website itself:
+This is the thesis site for ~dashus-navnul's discovery that FromSoftware's Elden Ring is a literal instantiation of Marcel Duchamp's *The Large Glass* (1915-1923).
 
-- `app/` for routes and API endpoints
-- `components/` for UI and site modules
-- `content/` for MDX source material
-- `data/` for generated Elden Ring and reference datasets
-- `public/` for images, animations, and proof artifacts
-- `scripts/` for content and asset maintenance utilities
+Live at [eldenringisthelargeglass.com](https://eldenringisthelargeglass.com).
 
 ## Stack
 
-- Next.js 13
-- React 18
-- TypeScript
+- Next.js 13.5.6 (App Router)
+- Contentlayer 0.3.4 (MDX pipeline)
 - Tailwind CSS
-- Contentlayer
+- TypeScript
+- Vercel (deployment)
+- Agentation (dev-only annotation workflow)
+
+## Content Architecture
+
+All long-form content lives in `content/` as MDX files compiled by Contentlayer.
+
+This is not a site where editorial content should be hardcoded into TypeScript. Route pages should remain thin and should render content loaded through `lib/content.ts` and `components/mdx/markdown-renderer.tsx`.
+
+If you are changing:
+
+- thesis copy
+- article copy
+- bibliography text
+- vocabulary/catalog content
+- critique copy
+
+start in `content/`, not in `app/(site)/*.tsx`.
+
+Structured interactive datasets live in `data/`, especially the title-card system.
 
 ## Local Development
 
-Requirements:
-
-- Node.js 18+
-- npm
-
-Run locally:
-
 ```bash
 npm install
-npm run dev
+npm run dev        # starts on localhost:3000
 ```
 
-Build and verification:
+The dev server runs Contentlayer on startup to compile MDX. First boot takes ~10s; subsequent hot reloads are fast.
 
 ```bash
-npm run typecheck
-npm run build
+npm run typecheck  # tsc --noEmit
+npm run build      # production build (same as what Vercel runs)
 ```
 
-## Notes
+## Agentation
 
-- `predev` and `prebuild` run `scripts/sync-critique-assets.js`
-- the imported site includes a large `public/` asset tree
-- this repo is intentionally the website-only extraction, not the full archived source project
+Agentation is installed for dev-time visual collaboration with AI agents.
 
-## Origin
+- it is wired through `components/agentation-dev.tsx`
+- it is only rendered in development via `app/layout.tsx`
+- use it to annotate exact content/UI on the running site when working with an LLM
 
-The initial import was reconstructed from `DashusNavnul/elden-ring-discovery` and narrowed to the website project surfaces so `eldengglass` can evolve as a clean standalone app repo.
+Preferred content workflow:
+
+1. run the site locally
+2. annotate the exact content with Agentation
+3. apply the real edit in `content/` or `data/`
+4. verify the result in-browser
+
+## Deployment
+
+The site deploys from [dalten-collective/elden-glass](https://github.com/dalten-collective/elden-glass) on Vercel:
+
+- `main` is production
+- `dev` is the integration branch
+- every PR and branch push gets a unique Vercel preview URL
+- [eldenringisthelargeglass.com](https://eldenringisthelargeglass.com) is the production site
+- [elden-glass.vercel.app](https://elden-glass.vercel.app) is the Vercel production alias
+
+Required workflow:
+
+1. branch from current `dev`
+2. make the change
+3. run local verification
+4. open a PR to `dev`
+5. request review
+6. merge to `dev`
+7. validate the deployed `dev` build online
+8. open a PR from `dev` to `main`
+9. request review
+10. merge `dev` to `main`
+
+Do not commit directly to `main`.
+
+Do not push directly to `main`.
+
+One environment variable is set in Vercel:
+
+- `NEXT_PUBLIC_BASE_URL` = `https://eldenringisthelargeglass.com`
+
+## Blockchain Attestations
+
+The site verifies two independent attestations of the original discovery:
+
+1. **Initial Thesis** -- SHA-256 hash of `manuscript.txt` attested on Ethereum via EAS (Ethereum Attestation Service). The hash and attestation UID are in the MDX frontmatter.
+2. **TL;DR** -- SHA-256 hash of `EldenRingSecretOriginal.md` timestamped on Bitcoin via OpenTimestamps. The `.ots` proof file is in `public/proofs/`.
+
+Both proof files are served from `public/proofs/` so readers can independently verify.
+
+## Project Structure
+
+```
+app/                    Routes and API endpoints
+  (site)/               All content pages (living-thesis, vocab, gatherer, etc.)
+  api/                  Title card, search, and sense-index endpoints
+components/
+  mdx/                  MDX components (MarkdownRenderer, DefinitionItem, FloatImage, etc.)
+  site/                 Layout (sidebar, top bar, navigation)
+  title-cards/          Rollover display, detail modal, provider
+  verification/         Hash verification UI
+content/                MDX source files
+data/                   Title cards JSON, sense index, xenotext theories
+lib/                    Content getters, search index, utilities
+public/
+  proofs/               Attestation proof files
+  images/               All site imagery (Duchamp works, ER characters, etc.)
+  animations/           Large Glass component GIFs
+```


### PR DESCRIPTION
## What
This PR brings the repository guidance docs into alignment so the public README, the collaborator-focused CLAUDE.md, and the agent-focused AGENTS.md all describe the same content model, Agentation workflow, and release process.

## Why
The repo had drifted into contradictory guidance. README still implied direct branch pushes as the deployment model, while the actual operating process is branch work into `dev`, online validation, and a separate promotion PR into `main`. These files should reinforce the real workflow, not compete with it.

## Changes
- Rewrite README around current architecture and release flow
- Add AGENTS.md with prescriptive agent rules
- Add CLAUDE.md with matching collaborator guidance
- Standardize MDX-first content and Agentation guidance

## Testing
- Read all three documents together for consistency
- Confirm deployment instructions match current `dev` -> `main` workflow
- No code paths changed; docs-only update
