### PR TITLE
fix: correct Rhonda Shearer sidebar ordering

### DIFF
--- a/content/pages/duchamp/rhonda-shearer/impossible-bed-ii.mdx
+++ b/content/pages/duchamp/rhonda-shearer/impossible-bed-ii.mdx
@@ -2,7 +2,7 @@
 title: 'The Impossible Bed, Part II'
 summary: "Rhonda Roland Shearer's second Impossible Bed essay argues that Duchamp's readymades were crafted clues and that the 3 Standard Stoppages form a verification toolkit linking art to Poincare's theory of discovery."
 updated: '2026-04-15'
-eyebrow: 'Shearer Essay - Part II'
+eyebrow: 'Shearer Essay — Part II'
 subtitle: 'A Possible Route of Influence From Art To Science'
 ---
 

--- a/content/pages/duchamp/rhonda-shearer/layout.yaml
+++ b/content/pages/duchamp/rhonda-shearer/layout.yaml
@@ -1,4 +1,4 @@
 order:
   - profile
-  - impossible-bed-ii
   - impossible-bed-i
+  - impossible-bed-ii


### PR DESCRIPTION
## What
This PR corrects the Rhonda Shearer sidebar ordering and standardizes the eyebrow text between the two Impossible Bed essays.

## Why
The sidebar currently lists Part II ahead of Part I, and the eyebrow text uses mixed dash styles across the two pages. This is a straightforward content/navigation consistency fix.

## Changes
- Put Impossible Bed Part I before Part II in the sidebar
- Standardize the Part II eyebrow to use an em dash

## Testing
- `npm run format:check`
- `npm run typecheck`
- `NEXT_TELEMETRY_DISABLED=1 npm run build`
