### PR TITLE
chore: promote dev to main

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -6,6 +6,11 @@ import { Button } from '@/components/ui/button';
 export default function HomePage() {
   return (
     <div className="space-y-12">
+      <p className="sr-only">
+        Agent readers: consult /llms.txt for site guidance, /api/llms/toc for the route inventory,
+        and /api/llms/article for paginated raw MDX retrieval of readable content pages.
+      </p>
+
       {/* Hero Section */}
       <section className="relative overflow-hidden -mt-6">
         <div className="glass-card border border-[var(--border-emphasis)] bg-gradient-to-br from-[rgb(var(--bg-secondary-rgb)/0.9)] via-[rgb(var(--bg-secondary-rgb)/0.7)] to-[rgb(var(--bg-secondary-rgb)/0.5)] pt-2 pb-4 px-4 lg:pt-3 lg:pb-5 lg:px-6">

--- a/app/api/llms/article/route.ts
+++ b/app/api/llms/article/route.ts
@@ -1,0 +1,111 @@
+import { NextResponse } from 'next/server';
+
+import {
+  getLlmReadableDocument,
+  getLlmRouteByPath,
+  LLM_ARTICLE_PAGE_SIZE_CHARS,
+  paginateLlmDocument,
+} from '@/lib/llms';
+
+/**
+ * Returns one page of raw MDX for a readable route from the LLM catalog.
+ */
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const path = searchParams.get('path');
+  const pageValue = searchParams.get('page') ?? '1';
+  const page = Number.parseInt(pageValue, 10);
+
+  if (!path) {
+    return NextResponse.json(
+      {
+        error: 'missing_path',
+        message: 'Query parameter "path" is required.',
+      },
+      { status: 400 }
+    );
+  }
+
+  if (!Number.isInteger(page) || page < 1) {
+    return NextResponse.json(
+      {
+        error: 'invalid_page',
+        message: 'Query parameter "page" must be a positive integer.',
+      },
+      { status: 400 }
+    );
+  }
+
+  const route = getLlmRouteByPath(path);
+
+  if (!route) {
+    return NextResponse.json(
+      {
+        error: 'unknown_path',
+        message: `No LLM catalog entry exists for "${path}".`,
+      },
+      { status: 404 }
+    );
+  }
+
+  if (!route.readable) {
+    return NextResponse.json(
+      {
+        error: 'non_readable_path',
+        message: `The route "${path}" is not retrievable through this endpoint.`,
+        kind: route.kind,
+        reason:
+          route.kind === 'interactive'
+            ? 'This route is interactive and does not have a stable MDX article body.'
+            : 'This route is an index page and does not have a single canonical MDX article body.',
+      },
+      { status: 409 }
+    );
+  }
+
+  const document = getLlmReadableDocument(path);
+
+  if (!document) {
+    return NextResponse.json(
+      {
+        error: 'unknown_path',
+        message: `No readable MDX document exists for "${path}".`,
+      },
+      { status: 404 }
+    );
+  }
+
+  const pages = paginateLlmDocument(document.content, LLM_ARTICLE_PAGE_SIZE_CHARS);
+  const pageCount = pages.length;
+
+  if (page > pageCount) {
+    return NextResponse.json(
+      {
+        error: 'page_out_of_range',
+        message: `Page ${page} does not exist for "${path}".`,
+        pageCount,
+      },
+      { status: 404 }
+    );
+  }
+
+  const content = pages[page - 1];
+  const charStart = pages.slice(0, page - 1).reduce((sum, segment) => sum + segment.length, 0);
+  const charEnd = charStart + content.length;
+
+  return NextResponse.json({
+    path: document.path,
+    title: document.title,
+    summary: document.summary,
+    format: document.format,
+    updated: document.updated,
+    page,
+    pageCount,
+    pageSizeChars: LLM_ARTICLE_PAGE_SIZE_CHARS,
+    charStart,
+    charEnd,
+    nextPage: page < pageCount ? page + 1 : null,
+    prevPage: page > 1 ? page - 1 : null,
+    content,
+  });
+}

--- a/app/api/llms/toc/route.ts
+++ b/app/api/llms/toc/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+
+import { getLlmRoutes } from '@/lib/llms';
+
+/**
+ * Returns the machine-readable site inventory for LLM clients.
+ */
+export async function GET() {
+  return NextResponse.json({
+    site: 'Elden Glass',
+    generatedAt: new Date().toISOString(),
+    entries: getLlmRoutes(),
+  });
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -63,6 +63,7 @@ export const metadata: Metadata = {
   alternates: {
     types: {
       'application/rss+xml': '/feed.xml',
+      'text/plain': '/llms.txt',
     },
   },
 };

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server';
+
+const llmsText = `# Elden Glass
+
+Elden Glass is a research site arguing that Elden Ring is a digital reimagining of Marcel Duchamp's The Bride Stripped Bare by Her Bachelors, Even (The Large Glass).
+
+Use this site through the LLM surface as follows:
+
+1. Fetch /api/llms/toc first.
+2. Read the returned entries array.
+3. For entries where readable=true, fetch /api/llms/article?path=<entry.path>&page=1.
+4. Continue paging with the same path and page=2, page=3, and so on until nextPage is null.
+
+Contract details:
+
+- /api/llms/toc returns JSON with the site's canonical LLM route inventory.
+- Each ToC entry includes path, title, summary, kind, readable, format, sourceType, and updated.
+- readable=true entries are MDX-backed documents retrievable through /api/llms/article.
+- /api/llms/article returns raw MDX body content, not rendered HTML.
+- /api/llms/article pages content at a maximum of 30000 characters per page.
+- Interactive and index routes may appear in the ToC with readable=false. Those routes should be navigated directly by a human user or browser rather than fetched through /api/llms/article.
+
+Important route kinds:
+
+- content: a readable MDX article or critique document.
+- interactive: a bespoke page with client-side behavior or structured UI rather than a single article body.
+- index: a listing or landing page that does not have one canonical article body.
+
+Known non-readable surfaces include the home page, the critiques index, the Gatherer title-card database, search, the xenotext tool, and Duchamp's works gallery.
+`;
+
+/**
+ * Returns plain-text discovery instructions for LLM clients.
+ */
+export async function GET() {
+  return new NextResponse(llmsText, {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600, s-maxage=3600',
+    },
+  });
+}

--- a/lib/llms.ts
+++ b/lib/llms.ts
@@ -1,0 +1,251 @@
+import {
+  allContentPagesSorted,
+  getContentPageBySlug,
+  getCritiqueBySlug,
+  getCritiques,
+} from '@/lib/content';
+
+export const LLM_ARTICLE_PAGE_SIZE_CHARS = 30_000;
+
+export type LlmRouteKind = 'content' | 'interactive' | 'index';
+export type LlmRouteFormat = 'mdx' | null;
+export type LlmRouteSource = 'contentPage' | 'critique' | 'bespoke';
+
+export type LlmRouteEntry = {
+  path: string;
+  title: string;
+  summary: string;
+  kind: LlmRouteKind;
+  readable: boolean;
+  format: LlmRouteFormat;
+  sourceType: LlmRouteSource;
+  updated: string | null;
+};
+
+type InternalLlmRouteEntry = LlmRouteEntry & {
+  sourceSlug?: string;
+};
+
+export type LlmReadableDocument = {
+  path: string;
+  title: string;
+  summary: string;
+  format: 'mdx';
+  updated: string | null;
+  content: string;
+};
+
+const staticLlmRoutes: InternalLlmRouteEntry[] = [
+  {
+    path: '/',
+    title: 'Home',
+    summary:
+      'Landing page introducing the Elden Glass thesis and pointing readers toward the main research documents.',
+    kind: 'index',
+    readable: false,
+    format: null,
+    sourceType: 'bespoke',
+    updated: null,
+  },
+  {
+    path: '/critiques',
+    title: 'Critiques & Responses',
+    summary:
+      'Index page listing critique dossiers and response essays about prior Elden Ring scholarship.',
+    kind: 'index',
+    readable: false,
+    format: null,
+    sourceType: 'bespoke',
+    updated: null,
+  },
+  {
+    path: '/gatherer',
+    title: 'Elden Ring Item Cards',
+    summary:
+      'Interactive database and search interface for Elden Ring title cards and related structured item data.',
+    kind: 'interactive',
+    readable: false,
+    format: null,
+    sourceType: 'bespoke',
+    updated: null,
+  },
+  {
+    path: '/search',
+    title: 'Search',
+    summary: 'Interactive full-site search interface for the research corpus.',
+    kind: 'interactive',
+    readable: false,
+    format: null,
+    sourceType: 'bespoke',
+    updated: null,
+  },
+  {
+    path: '/xenotext',
+    title: 'Xenotext',
+    summary:
+      'Interactive xenotext cipher and transformation engine with client-side state and visualization.',
+    kind: 'interactive',
+    readable: false,
+    format: null,
+    sourceType: 'bespoke',
+    updated: null,
+  },
+  {
+    path: '/duchamp/duchamp-works',
+    title: "Duchamp's Works",
+    summary:
+      'Interactive catalogue raisonne view of Duchamp artworks with modal detail browsing rather than article text.',
+    kind: 'interactive',
+    readable: false,
+    format: null,
+    sourceType: 'bespoke',
+    updated: null,
+  },
+];
+
+/**
+ * Returns the canonical LLM-facing inventory of human-readable site routes.
+ */
+export function getLlmRoutes(): LlmRouteEntry[] {
+  return getInternalLlmRoutes().map(stripInternalRouteFields);
+}
+
+/**
+ * Resolves one LLM catalog entry by its canonical absolute path.
+ */
+export function getLlmRouteByPath(routePath: string): LlmRouteEntry | null {
+  const match = getInternalLlmRoutes().find((entry) => entry.path === routePath);
+  return match ? stripInternalRouteFields(match) : null;
+}
+
+/**
+ * Resolves a readable MDX-backed document for article pagination.
+ */
+export function getLlmReadableDocument(routePath: string): LlmReadableDocument | null {
+  const route = getInternalLlmRoutes().find((entry) => entry.path === routePath);
+
+  if (!route || !route.readable || !route.format || !route.sourceSlug) {
+    return null;
+  }
+
+  if (route.sourceType === 'contentPage') {
+    const doc = getContentPageBySlug(route.sourceSlug);
+
+    if (!doc) {
+      return null;
+    }
+
+    return {
+      path: route.path,
+      title: doc.title,
+      summary: doc.summary,
+      format: 'mdx',
+      updated: doc.updated,
+      content: doc.body.raw,
+    };
+  }
+
+  if (route.sourceType === 'critique') {
+    const critique = getCritiqueBySlug(route.sourceSlug);
+
+    if (!critique) {
+      return null;
+    }
+
+    return {
+      path: route.path,
+      title: critique.title,
+      summary: critique.summary,
+      format: 'mdx',
+      updated: critique.updated,
+      content: critique.body.raw,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Splits raw MDX into stable article pages of at most the configured size.
+ */
+export function paginateLlmDocument(content: string, maxChars = LLM_ARTICLE_PAGE_SIZE_CHARS) {
+  if (content.length <= maxChars) {
+    return [content];
+  }
+
+  const blocks = content.split(/\n\s*\n/g);
+  const pages: string[] = [];
+  let currentPage = '';
+
+  // Keep paragraph-scale chunks together when possible, but hard-split any
+  // single block that exceeds the page size on its own.
+  for (const block of blocks) {
+    if (!block) {
+      continue;
+    }
+
+    const candidate = currentPage ? `${currentPage}\n\n${block}` : block;
+
+    if (candidate.length <= maxChars) {
+      currentPage = candidate;
+      continue;
+    }
+
+    if (currentPage) {
+      pages.push(currentPage);
+      currentPage = '';
+    }
+
+    if (block.length <= maxChars) {
+      currentPage = block;
+      continue;
+    }
+
+    for (let index = 0; index < block.length; index += maxChars) {
+      pages.push(block.slice(index, index + maxChars));
+    }
+  }
+
+  if (currentPage) {
+    pages.push(currentPage);
+  }
+
+  return pages.length ? pages : [''];
+}
+
+/**
+ * Builds the full internal route inventory, including resolver-only fields.
+ */
+function getInternalLlmRoutes(): InternalLlmRouteEntry[] {
+  const contentEntries: InternalLlmRouteEntry[] = allContentPagesSorted().map((doc) => ({
+    path: doc.url,
+    title: doc.title,
+    summary: doc.summary,
+    kind: 'content',
+    readable: true,
+    format: 'mdx',
+    sourceType: 'contentPage',
+    sourceSlug: doc.slug,
+    updated: doc.updated,
+  }));
+  const critiqueEntries: InternalLlmRouteEntry[] = getCritiques().map((critique) => ({
+    path: `/critiques/${critique.slug}`,
+    title: critique.title,
+    summary: critique.summary,
+    kind: 'content',
+    readable: true,
+    format: 'mdx',
+    sourceType: 'critique',
+    sourceSlug: critique.slug,
+    updated: critique.updated,
+  }));
+
+  return [...staticLlmRoutes, ...contentEntries, ...critiqueEntries].sort((left, right) =>
+    left.path.localeCompare(right.path)
+  );
+}
+
+function stripInternalRouteFields(entry: InternalLlmRouteEntry): LlmRouteEntry {
+  const { sourceSlug: _sourceSlug, ...publicEntry } = entry;
+  return publicEntry;
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -136,6 +136,23 @@ const nextConfig = {
       },
     ];
   },
+  async headers() {
+    return [
+      {
+        source: '/',
+        headers: [
+          {
+            key: 'Link',
+            value: '</llms.txt>; rel="llms-txt"',
+          },
+          {
+            key: 'X-Llms-Txt',
+            value: '/llms.txt',
+          },
+        ],
+      },
+    ];
+  },
   images: {
     domains: [
       'eldenring.wiki.fextralife.com',


### PR DESCRIPTION
## What
This PR promotes the current `dev` branch to `main`, releasing the new LLM access surface for Elden Glass. That includes the root `llms.txt` discovery document, the machine-readable route inventory endpoint, the paginated raw-MDX article endpoint, and the home-page hints that point agent readers toward those resources.

## Why
The LLM access work has already been reviewed and validated on the deployed `dev` environment. Promoting `dev` to `main` publishes that reviewed state to production without introducing any additional changes beyond what was confirmed online.

## Changes
- Promote reviewed `dev` state to production
- Release `/llms.txt` discovery document
- Release `/api/llms/toc` route inventory endpoint
- Release `/api/llms/article` paginated raw-MDX endpoint
- Release home-page `llms.txt` discovery headers
- Release hidden home-page LLM guidance text

## Testing
- Reviewed and merged PR #12 into `dev`
- Confirmed the `dev` deployment in Vercel
- Verified local `lint`, `format:check`, `typecheck`, and `check` during PR #12
- Verified `/llms.txt`, `/api/llms/toc`, and `/api/llms/article` locally before promotion
