### PR TITLE
fix: restore server-rendered homepage shell

### DIFF
--- a/components/site/scroll-to-text.tsx
+++ b/components/site/scroll-to-text.tsx
@@ -1,57 +1,69 @@
 'use client';
 
 import { useEffect } from 'react';
-import { useSearchParams } from 'next/navigation';
 
 export function ScrollToText() {
-  const searchParams = useSearchParams();
-
   useEffect(() => {
-    // Check if there's a text fragment in the URL
-    const hash = window.location.hash;
-    if (!hash.includes(':~:text=')) return;
+    const highlightTextFragment = () => {
+      const hash = window.location.hash;
 
-    // Extract the text to search for
-    const match = hash.match(/:~:text=([^&]+)/);
-    if (!match) return;
-
-    const searchText = decodeURIComponent(match[1]);
-
-    // Give the page a moment to render
-    setTimeout(() => {
-      // Find the text in the page
-      const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, null);
-
-      let node;
-      while ((node = walker.nextNode())) {
-        const text = node.textContent || '';
-        if (text.includes(searchText)) {
-          const element = node.parentElement;
-          if (element) {
-            // Scroll to the element
-            element.scrollIntoView({ behavior: 'smooth', block: 'center' });
-
-            // Highlight the text temporarily
-            const originalBg = element.style.backgroundColor;
-            const originalTransition = element.style.transition;
-
-            element.style.transition = 'background-color 0.3s ease';
-            element.style.backgroundColor = 'rgba(201, 169, 97, 0.3)'; // Accent gold with opacity
-
-            // Remove highlight after 3 seconds
-            setTimeout(() => {
-              element.style.backgroundColor = originalBg;
-              setTimeout(() => {
-                element.style.transition = originalTransition;
-              }, 300);
-            }, 3000);
-
-            break;
-          }
-        }
+      if (!hash.includes(':~:text=')) {
+        return;
       }
-    }, 500);
-  }, [searchParams]);
+
+      const match = hash.match(/:~:text=([^&]+)/);
+
+      if (!match) {
+        return;
+      }
+
+      const searchText = decodeURIComponent(match[1]);
+
+      // Give the page a moment to render before walking text nodes.
+      window.setTimeout(() => {
+        const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, null);
+        let node: Node | null;
+
+        while ((node = walker.nextNode())) {
+          const text = node.textContent || '';
+
+          if (!text.includes(searchText)) {
+            continue;
+          }
+
+          const element = node.parentElement;
+
+          if (!element) {
+            continue;
+          }
+
+          element.scrollIntoView({ behavior: 'smooth', block: 'center' });
+
+          const originalBg = element.style.backgroundColor;
+          const originalTransition = element.style.transition;
+
+          element.style.transition = 'background-color 0.3s ease';
+          element.style.backgroundColor = 'rgba(201, 169, 97, 0.3)';
+
+          window.setTimeout(() => {
+            element.style.backgroundColor = originalBg;
+            window.setTimeout(() => {
+              element.style.transition = originalTransition;
+            }, 300);
+          }, 3000);
+
+          break;
+        }
+      }, 500);
+    };
+
+    highlightTextFragment();
+    window.addEventListener('hashchange', highlightTextFragment);
+
+    return () => {
+      window.removeEventListener('hashchange', highlightTextFragment);
+    };
+  }, []);
 
   return null;
 }


### PR DESCRIPTION
## What
This PR removes the shared-shell client-side rendering bailout that was causing the homepage and other shell-driven routes to deopt into client-side rendering during production builds. It rewrites the text-fragment scrolling helper to react to `window.location.hash` directly instead of subscribing to Next search params from the site shell.

## Why
The current `ScrollToText` helper lives in the shared site shell and called `useSearchParams()`, which forced `/`, `/critiques`, and the MDX catch-all routes into a client-rendered shell. That degraded the server HTML seen by readability-style fetchers and directly undermined the homepage's usefulness to non-browser retrieval tools.

## Changes
- Remove `useSearchParams` from `ScrollToText`
- Drive text-fragment behavior from `window.location.hash`
- Re-run scroll/highlight logic on mount and `hashchange`
- Restore server-rendered shell output for homepage routes

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- Confirmed the previous `Entire page / deopted into client-side rendering` warnings no longer appear in the build output
