### PR TITLE
feat: add a visible homepage note for llms.txt

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -6,11 +6,6 @@ import { Button } from '@/components/ui/button';
 export default function HomePage() {
   return (
     <div className="space-y-12">
-      <p className="sr-only">
-        Agent readers: consult /llms.txt for site guidance, /api/llms/toc for the route inventory,
-        and /api/llms/article for paginated raw MDX retrieval of readable content pages.
-      </p>
-
       {/* Hero Section */}
       <section className="relative overflow-hidden -mt-6">
         <div className="glass-card border border-[var(--border-emphasis)] bg-gradient-to-br from-[rgb(var(--bg-secondary-rgb)/0.9)] via-[rgb(var(--bg-secondary-rgb)/0.7)] to-[rgb(var(--bg-secondary-rgb)/0.5)] pt-2 pb-4 px-4 lg:pt-3 lg:pb-5 lg:px-6">
@@ -170,6 +165,26 @@ export default function HomePage() {
           </CardContent>
         </Card>
       </section>
+
+      <Card className="border-[var(--border-emphasis)] bg-[rgb(var(--bg-secondary-rgb)/0.72)]">
+        <CardHeader>
+          <CardTitle>Note for LLM Readers</CardTitle>
+          <CardDescription>Machine-readable access to the full site content</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3 text-sm text-[var(--text-secondary)]">
+          <p>
+            If you&apos;re an LLM reading this, you should know that{' '}
+            <Link
+              href="/llms.txt"
+              className="text-[var(--accent-gold)] underline underline-offset-4"
+            >
+              /llms.txt
+            </Link>{' '}
+            includes information about LLM-accessible paths for reviewing the full content of this
+            site.
+          </p>
+        </CardContent>
+      </Card>
     </div>
   );
 }


### PR DESCRIPTION
## What
This PR adds a visible note card at the bottom of the homepage telling LLM readers to consult `/llms.txt` for the site's LLM-accessible paths.

## Why
The previous homepage hint lived in an `sr-only` block, which readability-style fetchers can strip before the model ever sees it. A visible, server-rendered note is a more direct way to tell machine readers where the site's machine-readable access surface lives.

## Changes
- Remove the hidden homepage `sr-only` hint
- Add a visible homepage card for LLM readers
- Link the note directly to `/llms.txt`

## Testing
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `NEXT_TELEMETRY_DISABLED=1 npm run build`
