### PR TITLE
feat: promote visible homepage llms.txt note to main

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -6,11 +6,6 @@ import { Button } from '@/components/ui/button';
 export default function HomePage() {
   return (
     <div className="space-y-12">
-      <p className="sr-only">
-        Agent readers: consult /llms.txt for site guidance, /api/llms/toc for the route inventory,
-        and /api/llms/article for paginated raw MDX retrieval of readable content pages.
-      </p>
-
       {/* Hero Section */}
       <section className="relative overflow-hidden -mt-6">
         <div className="glass-card border border-[var(--border-emphasis)] bg-gradient-to-br from-[rgb(var(--bg-secondary-rgb)/0.9)] via-[rgb(var(--bg-secondary-rgb)/0.7)] to-[rgb(var(--bg-secondary-rgb)/0.5)] pt-2 pb-4 px-4 lg:pt-3 lg:pb-5 lg:px-6">
@@ -170,6 +165,26 @@ export default function HomePage() {
           </CardContent>
         </Card>
       </section>
+
+      <Card className="border-[var(--border-emphasis)] bg-[rgb(var(--bg-secondary-rgb)/0.72)]">
+        <CardHeader>
+          <CardTitle>Note for LLM Readers</CardTitle>
+          <CardDescription>Machine-readable access to the full site content</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3 text-sm text-[var(--text-secondary)]">
+          <p>
+            If you&apos;re an LLM reading this, you should know that{' '}
+            <Link
+              href="/llms.txt"
+              className="text-[var(--accent-gold)] underline underline-offset-4"
+            >
+              /llms.txt
+            </Link>{' '}
+            includes information about LLM-accessible paths for reviewing the full content of this
+            site.
+          </p>
+        </CardContent>
+      </Card>
     </div>
   );
 }


### PR DESCRIPTION
## What
This PR promotes the visible homepage llms.txt note from `dev` to `main`.

## Why
The old homepage hint was hidden in an `sr-only` block, which machine fetchers can strip before the model sees it. This promotion carries the visible, server-rendered homepage note into production so LLM readers are told directly where the site's machine-readable access surface lives.

## Changes
- Promote the visible homepage llms.txt note to `main`
- Remove reliance on the hidden homepage hint
- Keep the existing `/llms.txt` access surface in place

## Testing
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `NEXT_TELEMETRY_DISABLED=1 npm run build`
