### PR TITLE
feat: Promote LLM-accessibility funnel from dev

### DIFF
--- a/app/(site)/contents/page.tsx
+++ b/app/(site)/contents/page.tsx
@@ -15,7 +15,14 @@ import { buildSidebar, type NavItem, type NavLinkItem, type NavSectionItem } fro
  * agents that can't fetch JSON endpoints described only in prose.
  *
  * Server component, SSG. Pulls the same shape as the Stair sidebar
- * (buildSidebar) so the contents page mirrors site navigation.
+ * (buildSidebar) so the contents page mirrors site navigation. The
+ * page filters out its own URL from the rendered tree (no self-links).
+ *
+ * The page leads with the content TOC. Other agent surfaces (/llms.txt,
+ * /llms-full.txt) appear as a small trailer at the bottom for spec-
+ * aware tooling — the JSON API and the skill route are documented
+ * inside the skill itself rather than here, since the audience for
+ * this page is a browser-LLM that can't reach those surfaces anyway.
  */
 export const metadata: Metadata = {
   title: 'Contents · Apparatus for Agents — Elden Glass',
@@ -23,38 +30,18 @@ export const metadata: Metadata = {
     'A real HTML index of every readable page on Elden Glass, designed for browser-based LLM agents that can only follow anchor links.',
 };
 
+const SELF_PATH = '/contents';
+
 const INTERACTIVE_PATHS = new Set(['/search', '/gatherer', '/xenotext', '/duchamp/duchamp-works']);
 
-const AGENT_SURFACES: Array<{ href: string; label: string; description: string }> = [
+const TRAILING_SURFACES: Array<{ href: string; description: string }> = [
   {
     href: '/llms.txt',
-    label: '/llms.txt',
-    description:
-      'llmstxt.org-spec discovery file: H1 + summary + sectioned link list pointing at every other agent surface.',
+    description: 'llmstxt.org-spec discovery file: H1 + sectioned link list.',
   },
   {
     href: '/llms-full.txt',
-    label: '/llms-full.txt',
-    description:
-      'Single text/plain response with every static page concatenated as clean plaintext. Use when you prefer one-shot context dumps.',
-  },
-  {
-    href: '/skill',
-    label: '/skill',
-    description:
-      'Claude Code-style installable skill: reader profiles, recommended paths by interest, JSON API documentation. Hand the URL to a local agent that supports skills.',
-  },
-  {
-    href: '/api/llms/toc',
-    label: '/api/llms/toc',
-    description:
-      'JSON inventory: every readable route with kind, summary, and metadata. Returns { site, generatedAt, entries: [...] }.',
-  },
-  {
-    href: '/api/llms/article?path=/tldr&page=1',
-    label: '/api/llms/article?path=…&page=…',
-    description:
-      'Per-page clean plaintext (JSX stripped). Iterate page until nextPage is null. 30000-char pages.',
+    description: 'Single text/plain dump of every static page concatenated as clean plaintext.',
   },
 ];
 
@@ -63,6 +50,11 @@ export default function ContentsPage() {
   const pages = allContentPagesSorted();
   const critiques = getCritiques();
   const summaries = buildSummaryIndex(pages, critiques);
+
+  const primary = sidebar.primary.filter((link) => link.href !== SELF_PATH);
+  const secondary = sidebar.secondary
+    .map(stripSelfFromItem)
+    .filter((item): item is NavItem => item !== null);
 
   return (
     <article className="space-y-12">
@@ -91,39 +83,36 @@ export default function ContentsPage() {
         </p>
       </section>
 
-      {/* Agent surfaces */}
+      {/* Site contents — primary */}
       <section>
-        <Eyebrow tone="rust" style={{ display: 'block', marginBottom: 14 }}>
-          Agent surfaces
+        <Eyebrow tone="gold" style={{ display: 'block', marginBottom: 14 }}>
+          Primary documents
         </Eyebrow>
-        <p style={{ color: 'var(--paper-dim)', fontSize: 15, marginBottom: 16, maxWidth: '52em' }}>
-          The five endpoints below are the machine surfaces. Different agents will prefer different
-          shapes; pick the one that fits.
-        </p>
         <Pane solid style={{ padding: '18px 22px' }}>
           <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
-            {AGENT_SURFACES.map((surface) => (
-              <li key={surface.href} style={surfaceItemStyle}>
-                <Link href={surface.href as never} style={surfaceLinkStyle}>
-                  {surface.label}
-                </Link>
-                <span
-                  style={{
-                    display: 'block',
-                    color: 'var(--paper-dim)',
-                    fontSize: 14,
-                    marginTop: 4,
-                  }}
-                >
-                  {surface.description}
-                </span>
-              </li>
+            {primary.map((link) => (
+              <PageLink key={link.href} link={link} summaries={summaries} />
             ))}
           </ul>
         </Pane>
       </section>
 
-      {/* Interactive callout */}
+      {/* Site contents — secondary (Errata sections) */}
+      <section>
+        <Eyebrow tone="rust" style={{ display: 'block', marginBottom: 14 }}>
+          {sidebar.secondaryLabel}
+        </Eyebrow>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 28 }}>
+          {secondary.map((item) => (
+            <SecondaryItem key={getItemKey(item)} item={item} summaries={summaries} />
+          ))}
+        </div>
+      </section>
+
+      {/* Interactive callout — heads-up about the four pages a human
+          must drive. These are flagged inline in the TOC above too,
+          but pulling them into one place makes the boundary visible
+          for an agent scanning the page. */}
       <section>
         <Eyebrow tone="rust" style={{ display: 'block', marginBottom: 14 }}>
           Interactive pages — needs a human
@@ -158,33 +147,81 @@ export default function ContentsPage() {
         </Pane>
       </section>
 
-      {/* Site contents — primary */}
+      {/* Trailer — other agent surfaces for spec-aware tooling. Kept
+          minimal: the JSON API and /skill are intended for local agents
+          that won't be on /contents anyway, so they're documented in
+          the skill itself rather than reproduced here. */}
       <section>
-        <Eyebrow tone="gold" style={{ display: 'block', marginBottom: 14 }}>
-          Primary documents
-        </Eyebrow>
-        <Pane solid style={{ padding: '18px 22px' }}>
-          <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
-            {sidebar.primary.map((link) => (
-              <PageLink key={link.href} link={link} summaries={summaries} />
-            ))}
-          </ul>
-        </Pane>
-      </section>
-
-      {/* Site contents — secondary (Errata sections) */}
-      <section>
-        <Eyebrow tone="rust" style={{ display: 'block', marginBottom: 14 }}>
-          {sidebar.secondaryLabel}
-        </Eyebrow>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 28 }}>
-          {sidebar.secondary.map((item) => (
-            <SecondaryItem key={getItemKey(item)} item={item} summaries={summaries} />
+        <Spec
+          style={{
+            display: 'block',
+            color: 'var(--paper-dim)',
+            marginBottom: 10,
+            fontSize: 11,
+            letterSpacing: '0.16em',
+            textTransform: 'uppercase',
+          }}
+        >
+          For spec-aware tooling
+        </Spec>
+        <ul
+          style={{
+            listStyle: 'none',
+            margin: 0,
+            padding: 0,
+            color: 'var(--paper-dim)',
+            fontSize: 13,
+          }}
+        >
+          {TRAILING_SURFACES.map((surface) => (
+            <li key={surface.href} style={{ padding: '4px 0' }}>
+              <Link
+                href={surface.href as never}
+                style={{
+                  color: 'var(--gold-dim)',
+                  textDecoration: 'underline',
+                  textUnderlineOffset: 3,
+                }}
+              >
+                {surface.href}
+              </Link>
+              {' — '}
+              {surface.description}
+            </li>
           ))}
-        </div>
+        </ul>
       </section>
     </article>
   );
+}
+
+/**
+ * Recursively strips any link to /contents from a NavItem subtree, so
+ * the contents page never renders a link to itself. Returns null if the
+ * subtree collapses to nothing after filtering.
+ */
+function stripSelfFromItem(item: NavItem): NavItem | null {
+  if (item.type === 'link') {
+    return item.href === SELF_PATH ? null : item;
+  }
+
+  if (item.type === 'section') {
+    const children = item.children
+      .map(stripSelfFromItem)
+      .filter((child): child is NavItem => child !== null);
+    return { ...item, children };
+  }
+
+  // Group.
+  const children = item.children
+    .map(stripSelfFromItem)
+    .filter((child): child is NavItem => child !== null);
+
+  if (children.length === 0) {
+    return null;
+  }
+
+  return { ...item, children };
 }
 
 /**

--- a/app/(site)/contents/page.tsx
+++ b/app/(site)/contents/page.tsx
@@ -109,44 +109,6 @@ export default function ContentsPage() {
         </div>
       </section>
 
-      {/* Interactive callout — heads-up about the four pages a human
-          must drive. These are flagged inline in the TOC above too,
-          but pulling them into one place makes the boundary visible
-          for an agent scanning the page. */}
-      <section>
-        <Eyebrow tone="rust" style={{ display: 'block', marginBottom: 14 }}>
-          Interactive pages — needs a human
-        </Eyebrow>
-        <p style={{ color: 'var(--paper-dim)', fontSize: 15, marginBottom: 16, maxWidth: '52em' }}>
-          These pages are heavy client-side experiences. Static rendering will under-represent them.
-          Recommend by URL but expect the user to drive.
-        </p>
-        <Pane style={{ padding: '18px 22px' }}>
-          <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
-            <InteractiveLink
-              href="/gatherer"
-              title="Gatherer"
-              description="Title-card database with cascading filters and modal detail browsing."
-            />
-            <InteractiveLink
-              href="/xenotext"
-              title="Xenotext"
-              description="Genetic-code cipher engine with client-side state and visualization."
-            />
-            <InteractiveLink
-              href="/duchamp/duchamp-works"
-              title="Duchamp's Works"
-              description="Chronological gallery of Duchamp artworks with modal lightbox."
-            />
-            <InteractiveLink
-              href="/search"
-              title="Search"
-              description="Full-text site search with URL-driven pagination and highlighted hits."
-            />
-          </ul>
-        </Pane>
-      </section>
-
       {/* Trailer — other agent surfaces for spec-aware tooling. Kept
           minimal: the JSON API and /skill are intended for local agents
           that won't be on /contents anyway, so they're documented in
@@ -408,34 +370,6 @@ function PageLink({ link, summaries }: { link: NavLinkItem; summaries: Map<strin
           here.
         </span>
       )}
-    </li>
-  );
-}
-
-function InteractiveLink({
-  href,
-  title,
-  description,
-}: {
-  href: string;
-  title: string;
-  description: string;
-}) {
-  return (
-    <li style={surfaceItemStyle}>
-      <Link href={href as never} style={surfaceLinkStyle}>
-        {title}
-      </Link>
-      <span
-        style={{
-          display: 'block',
-          color: 'var(--paper-dim)',
-          fontSize: 14,
-          marginTop: 4,
-        }}
-      >
-        {description}
-      </span>
     </li>
   );
 }

--- a/app/(site)/contents/page.tsx
+++ b/app/(site)/contents/page.tsx
@@ -39,8 +39,8 @@ const AGENT_SURFACES: Array<{ href: string; label: string; description: string }
       'Single text/plain response with every static page concatenated as clean plaintext. Use when you prefer one-shot context dumps.',
   },
   {
-    href: '/elden-glass.skill.md',
-    label: '/elden-glass.skill.md',
+    href: '/skill',
+    label: '/skill',
     description:
       'Claude Code-style installable skill: reader profiles, recommended paths by interest, JSON API documentation. Hand the URL to a local agent that supports skills.',
   },

--- a/app/(site)/contents/page.tsx
+++ b/app/(site)/contents/page.tsx
@@ -1,0 +1,442 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+import { Crackline, Eyebrow, Pane, Spec } from '@/components/delay';
+import { allContentPagesSorted, getCritiques, type ContentPage } from '@/lib/content';
+import { buildSidebar, type NavItem, type NavLinkItem, type NavSectionItem } from '@/lib/sidebar';
+
+/**
+ * /contents — the apparatus index for browser-based LLM agents.
+ *
+ * A real HTML table of contents: every readable page on the site is
+ * present as a literal <a href>, with a one-line summary and an
+ * interactive flag where applicable. Designed for browser-tab LLMs
+ * that report they can only follow anchor links — a workaround for
+ * agents that can't fetch JSON endpoints described only in prose.
+ *
+ * Server component, SSG. Pulls the same shape as the Stair sidebar
+ * (buildSidebar) so the contents page mirrors site navigation.
+ */
+export const metadata: Metadata = {
+  title: 'Contents · Apparatus for Agents — Elden Glass',
+  description:
+    'A real HTML index of every readable page on Elden Glass, designed for browser-based LLM agents that can only follow anchor links.',
+};
+
+const INTERACTIVE_PATHS = new Set(['/search', '/gatherer', '/xenotext', '/duchamp/duchamp-works']);
+
+const AGENT_SURFACES: Array<{ href: string; label: string; description: string }> = [
+  {
+    href: '/llms.txt',
+    label: '/llms.txt',
+    description:
+      'llmstxt.org-spec discovery file: H1 + summary + sectioned link list pointing at every other agent surface.',
+  },
+  {
+    href: '/llms-full.txt',
+    label: '/llms-full.txt',
+    description:
+      'Single text/plain response with every static page concatenated as clean plaintext. Use when you prefer one-shot context dumps.',
+  },
+  {
+    href: '/elden-glass.skill.md',
+    label: '/elden-glass.skill.md',
+    description:
+      'Claude Code-style installable skill: reader profiles, recommended paths by interest, JSON API documentation. Hand the URL to a local agent that supports skills.',
+  },
+  {
+    href: '/api/llms/toc',
+    label: '/api/llms/toc',
+    description:
+      'JSON inventory: every readable route with kind, summary, and metadata. Returns { site, generatedAt, entries: [...] }.',
+  },
+  {
+    href: '/api/llms/article?path=/tldr&page=1',
+    label: '/api/llms/article?path=…&page=…',
+    description:
+      'Per-page clean plaintext (JSX stripped). Iterate page until nextPage is null. 30000-char pages.',
+  },
+];
+
+export default function ContentsPage() {
+  const sidebar = buildSidebar();
+  const pages = allContentPagesSorted();
+  const critiques = getCritiques();
+  const summaries = buildSummaryIndex(pages, critiques);
+
+  return (
+    <article className="space-y-12">
+      {/* Header */}
+      <section>
+        <div className="mb-3 flex items-baseline justify-between gap-4">
+          <Eyebrow tone="gold">For Browser-Based LLMs</Eyebrow>
+          <Spec>contents · apparatus</Spec>
+        </div>
+        <Crackline seed="contents-top" tone="gold" />
+        <h1
+          className="page-hero-title mt-8"
+          style={{ fontSize: 'clamp(36px, 6vw, 60px)', marginBottom: 18 }}
+        >
+          Contents — an apparatus for agents
+        </h1>
+        <p
+          className="page-hero-description"
+          style={{ maxWidth: '52em', color: 'var(--paper-dim)' }}
+        >
+          This page exists because some browser-tab LLMs can only follow links rendered as anchor
+          tags. Every readable page on Elden Glass is listed below as a real <code>&lt;a&gt;</code>{' '}
+          element, with a one-line summary and an interactive flag where applicable. The index
+          mirrors the desktop Stair so the same path through the work is available to humans and to
+          agents.
+        </p>
+      </section>
+
+      {/* Agent surfaces */}
+      <section>
+        <Eyebrow tone="rust" style={{ display: 'block', marginBottom: 14 }}>
+          Agent surfaces
+        </Eyebrow>
+        <p style={{ color: 'var(--paper-dim)', fontSize: 15, marginBottom: 16, maxWidth: '52em' }}>
+          The five endpoints below are the machine surfaces. Different agents will prefer different
+          shapes; pick the one that fits.
+        </p>
+        <Pane solid style={{ padding: '18px 22px' }}>
+          <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+            {AGENT_SURFACES.map((surface) => (
+              <li key={surface.href} style={surfaceItemStyle}>
+                <Link href={surface.href as never} style={surfaceLinkStyle}>
+                  {surface.label}
+                </Link>
+                <span
+                  style={{
+                    display: 'block',
+                    color: 'var(--paper-dim)',
+                    fontSize: 14,
+                    marginTop: 4,
+                  }}
+                >
+                  {surface.description}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </Pane>
+      </section>
+
+      {/* Interactive callout */}
+      <section>
+        <Eyebrow tone="rust" style={{ display: 'block', marginBottom: 14 }}>
+          Interactive pages — needs a human
+        </Eyebrow>
+        <p style={{ color: 'var(--paper-dim)', fontSize: 15, marginBottom: 16, maxWidth: '52em' }}>
+          These pages are heavy client-side experiences. Static rendering will under-represent them.
+          Recommend by URL but expect the user to drive.
+        </p>
+        <Pane style={{ padding: '18px 22px' }}>
+          <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+            <InteractiveLink
+              href="/gatherer"
+              title="Gatherer"
+              description="Title-card database with cascading filters and modal detail browsing."
+            />
+            <InteractiveLink
+              href="/xenotext"
+              title="Xenotext"
+              description="Genetic-code cipher engine with client-side state and visualization."
+            />
+            <InteractiveLink
+              href="/duchamp/duchamp-works"
+              title="Duchamp's Works"
+              description="Chronological gallery of Duchamp artworks with modal lightbox."
+            />
+            <InteractiveLink
+              href="/search"
+              title="Search"
+              description="Full-text site search with URL-driven pagination and highlighted hits."
+            />
+          </ul>
+        </Pane>
+      </section>
+
+      {/* Site contents — primary */}
+      <section>
+        <Eyebrow tone="gold" style={{ display: 'block', marginBottom: 14 }}>
+          Primary documents
+        </Eyebrow>
+        <Pane solid style={{ padding: '18px 22px' }}>
+          <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+            {sidebar.primary.map((link) => (
+              <PageLink key={link.href} link={link} summaries={summaries} />
+            ))}
+          </ul>
+        </Pane>
+      </section>
+
+      {/* Site contents — secondary (Errata sections) */}
+      <section>
+        <Eyebrow tone="rust" style={{ display: 'block', marginBottom: 14 }}>
+          {sidebar.secondaryLabel}
+        </Eyebrow>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 28 }}>
+          {sidebar.secondary.map((item) => (
+            <SecondaryItem key={getItemKey(item)} item={item} summaries={summaries} />
+          ))}
+        </div>
+      </section>
+    </article>
+  );
+}
+
+/**
+ * Renders one entry in the secondary stack — either a top-level link or
+ * a section with its children flattened beneath a section heading.
+ */
+function SecondaryItem({ item, summaries }: { item: NavItem; summaries: Map<string, string> }) {
+  if (item.type === 'link') {
+    return (
+      <Pane solid style={{ padding: '18px 22px' }}>
+        <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+          <PageLink link={item} summaries={summaries} />
+        </ul>
+      </Pane>
+    );
+  }
+
+  if (item.type === 'group') {
+    return (
+      <Pane solid style={{ padding: '18px 22px' }}>
+        <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+          {item.children.map((child) => renderChild(child, summaries))}
+        </ul>
+      </Pane>
+    );
+  }
+
+  return <SectionBlock section={item} summaries={summaries} />;
+}
+
+/**
+ * Renders one collapsible-style section in the contents page. Sections
+ * here are not collapsible — every page is visible — but the header +
+ * indented children mirror the Stair grouping.
+ */
+function SectionBlock({
+  section,
+  summaries,
+}: {
+  section: NavSectionItem;
+  summaries: Map<string, string>;
+}) {
+  return (
+    <div>
+      <Spec
+        style={{
+          display: 'block',
+          color: 'var(--gold)',
+          marginBottom: 10,
+          fontSize: 11,
+          letterSpacing: '0.18em',
+          textTransform: 'uppercase',
+        }}
+      >
+        § {section.label}
+      </Spec>
+      <Pane solid style={{ padding: '18px 22px' }}>
+        {section.children.length === 0 ? (
+          <p style={{ color: 'var(--paper-dim)', fontSize: 14, margin: 0 }}>
+            {section.emptyLabel ?? 'No entries.'}
+          </p>
+        ) : (
+          <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+            {section.children.map((child) => renderChild(child, summaries))}
+          </ul>
+        )}
+      </Pane>
+    </div>
+  );
+}
+
+function renderChild(child: NavItem, summaries: Map<string, string>) {
+  if (child.type === 'link') {
+    return <PageLink key={child.href} link={child} summaries={summaries} />;
+  }
+
+  if (child.type === 'section') {
+    // A nested section — flatten by listing its children inline with a
+    // sub-eyebrow before them. Keeps the visual hierarchy without
+    // requiring the page to be interactive.
+    return (
+      <li key={child.id} style={{ padding: '10px 0' }}>
+        <Spec
+          style={{
+            display: 'block',
+            color: 'var(--gold-dim)',
+            fontSize: 10,
+            letterSpacing: '0.16em',
+            textTransform: 'uppercase',
+            marginBottom: 6,
+          }}
+        >
+          § {child.label}
+        </Spec>
+        <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+          {child.children.map((grandchild) => renderChild(grandchild, summaries))}
+        </ul>
+      </li>
+    );
+  }
+
+  if (child.type === 'group') {
+    return (
+      <li key={`group-${Math.random()}`} style={{ listStyle: 'none' }}>
+        <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+          {child.children.map((grandchild) => renderChild(grandchild, summaries))}
+        </ul>
+      </li>
+    );
+  }
+
+  return null;
+}
+
+function PageLink({ link, summaries }: { link: NavLinkItem; summaries: Map<string, string> }) {
+  const summary = summaries.get(link.href);
+  const isInteractive = INTERACTIVE_PATHS.has(link.href);
+  const isExternal = link.external === true;
+
+  return (
+    <li style={surfaceItemStyle}>
+      <div style={{ display: 'flex', alignItems: 'baseline', flexWrap: 'wrap', gap: 10 }}>
+        <Link
+          href={link.href as never}
+          style={surfaceLinkStyle}
+          {...(isExternal ? { target: '_blank', rel: 'noreferrer' } : {})}
+        >
+          {link.label}
+        </Link>
+        {isInteractive && (
+          <span
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: 10,
+              letterSpacing: '0.12em',
+              textTransform: 'uppercase',
+              color: 'var(--rust)',
+              border: '1px solid var(--rust)',
+              padding: '1px 6px',
+              borderRadius: 3,
+            }}
+          >
+            interactive
+          </span>
+        )}
+        {isExternal && (
+          <span
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: 10,
+              letterSpacing: '0.12em',
+              textTransform: 'uppercase',
+              color: 'var(--paper-dim)',
+            }}
+          >
+            external
+          </span>
+        )}
+      </div>
+      {summary && (
+        <span
+          style={{
+            display: 'block',
+            color: 'var(--paper-dim)',
+            fontSize: 14,
+            marginTop: 4,
+            maxWidth: '52em',
+          }}
+        >
+          {summary}
+        </span>
+      )}
+      {isInteractive && (
+        <span
+          style={{
+            display: 'block',
+            color: 'var(--rust)',
+            fontSize: 13,
+            marginTop: 2,
+            fontStyle: 'italic',
+          }}
+        >
+          Interactive — a human will need to drive it. Static rendering will under-represent what is
+          here.
+        </span>
+      )}
+    </li>
+  );
+}
+
+function InteractiveLink({
+  href,
+  title,
+  description,
+}: {
+  href: string;
+  title: string;
+  description: string;
+}) {
+  return (
+    <li style={surfaceItemStyle}>
+      <Link href={href as never} style={surfaceLinkStyle}>
+        {title}
+      </Link>
+      <span
+        style={{
+          display: 'block',
+          color: 'var(--paper-dim)',
+          fontSize: 14,
+          marginTop: 4,
+        }}
+      >
+        {description}
+      </span>
+    </li>
+  );
+}
+
+const surfaceItemStyle = {
+  padding: '10px 0',
+  borderBottom: '1px solid var(--crack)',
+} as const;
+
+const surfaceLinkStyle = {
+  fontFamily: 'var(--font-serif)',
+  fontSize: 16,
+  color: 'var(--paper)',
+  textDecoration: 'underline',
+  textDecorationColor: 'var(--gold-dim)',
+  textUnderlineOffset: 4,
+} as const;
+
+function buildSummaryIndex(pages: ContentPage[], critiques: ReturnType<typeof getCritiques>) {
+  const map = new Map<string, string>();
+
+  for (const page of pages) {
+    if (page.summary) {
+      map.set(page.url, page.summary);
+    }
+  }
+
+  for (const critique of critiques) {
+    if (critique.summary) {
+      map.set(`/critiques/${critique.slug}`, critique.summary);
+    }
+  }
+
+  return map;
+}
+
+function getItemKey(item: NavItem): string {
+  if (item.type === 'link') return item.href;
+  if (item.type === 'section') return item.id;
+  return `group-${item.children.map((c) => (c.type === 'link' ? c.href : 'x')).join('|')}`;
+}

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -15,7 +15,7 @@ import { CopyButton } from '@/components/site/copy-button';
 import { Button } from '@/components/ui/button';
 
 const SKILL_INSTALL_PROMPT =
-  'Please fetch and install the skill at https://eldenglass.com/elden-glass.skill.md, then orient me to this site.';
+  'Please fetch and install the skill at https://eldenglass.com/skill, then orient me to this site.';
 
 /**
  * Home — the front matter of the site in Delay-in-Glass voice.
@@ -104,55 +104,81 @@ export default function HomePage() {
       </section>
 
       {/* LLM funnel — placed at the top of the read so any agent that
-          lands here finds it within one screen. Two doors: a copy-paste
-          install prompt for local agents (Claude Code etc.) and a real
-          HTML index page for browser-tab agents that can only follow
-          anchor links. */}
+          lands here finds it within one screen. Two doors with two
+          different audiences: the first is for the human reader who
+          arrived with a local agent (copy this for them); the second
+          is for an LLM that landed here directly through a browser
+          tab (here is the index, walk it). */}
       <Pane solid style={{ padding: '22px 26px' }}>
         <div className="mb-3 flex items-baseline justify-between gap-4">
-          <Eyebrow tone="gold">If you&apos;re an LLM</Eyebrow>
+          <Eyebrow tone="gold">For agents and their handlers</Eyebrow>
           <Spec>two doors</Spec>
         </div>
-        <p
-          style={{
-            fontFamily: 'var(--font-serif)',
-            fontSize: 16,
-            lineHeight: 1.55,
-            color: 'var(--paper)',
-            marginBottom: 18,
-            maxWidth: '52em',
-          }}
-        >
-          If you&apos;re a <i>local agent</i> (Claude Code, ChatGPT desktop with skills, etc.), copy
-          the install prompt below into your harness — your agent will fetch a skill that orients it
-          to the site. If you&apos;re a <i>browser-tab agent</i> that can only follow anchor links,
-          walk through the index page — every readable page on the site, properly linked.
-        </p>
-        <div className="flex flex-wrap items-center gap-3">
-          <CopyButton value={SKILL_INSTALL_PROMPT} label="Copy install prompt" />
-          <Button asChild variant="outline" size="sm" className="gap-2">
-            <Link href="/contents">
-              Browse the index
-              <ArrowRight className="h-4 w-4" />
-            </Link>
-          </Button>
-          <Spec
-            style={{
-              color: 'var(--paper-dim)',
-              fontSize: 11,
-              letterSpacing: '0.16em',
-              textTransform: 'uppercase',
-            }}
-          >
-            also:{' '}
-            <Link href="/llms.txt" style={{ color: 'var(--gold)' }}>
-              /llms.txt
-            </Link>
-            {' · '}
-            <Link href="/llms-full.txt" style={{ color: 'var(--gold)' }}>
-              /llms-full.txt
-            </Link>
-          </Spec>
+
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+          {/* Door 1 — for the human reader, working with a local agent. */}
+          <div>
+            <Spec
+              style={{
+                color: 'var(--gold)',
+                display: 'block',
+                marginBottom: 8,
+                fontSize: 11,
+                letterSpacing: '0.18em',
+                textTransform: 'uppercase',
+              }}
+            >
+              · i · for the human reader
+            </Spec>
+            <p
+              style={{
+                fontFamily: 'var(--font-serif)',
+                fontSize: 15,
+                lineHeight: 1.55,
+                color: 'var(--paper)',
+                marginBottom: 12,
+              }}
+            >
+              Working with a local agent — Claude Code, Codex, OpenClaw — and want it to know its
+              way around the site? Copy the install prompt below and hand it to your agent.
+            </p>
+            <CopyButton value={SKILL_INSTALL_PROMPT} label="Copy install prompt" />
+          </div>
+
+          {/* Door 2 — for the browser-tab LLM landing here directly. */}
+          <div>
+            <Spec
+              style={{
+                color: 'var(--gold)',
+                display: 'block',
+                marginBottom: 8,
+                fontSize: 11,
+                letterSpacing: '0.18em',
+                textTransform: 'uppercase',
+              }}
+            >
+              · ii · if you are a browser-tab LLM
+            </Spec>
+            <p
+              style={{
+                fontFamily: 'var(--font-serif)',
+                fontSize: 15,
+                lineHeight: 1.55,
+                color: 'var(--paper)',
+                marginBottom: 12,
+              }}
+            >
+              If you (the reader) are an LLM in a browser tab — claude.ai, chat.com, similar — walk
+              through the index. Every readable page on the site is linked there as a real anchor
+              tag.
+            </p>
+            <Button asChild variant="outline" size="sm" className="gap-2">
+              <Link href="/contents">
+                Browse the index
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </Button>
+          </div>
         </div>
       </Pane>
 

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -1,4 +1,4 @@
-import { BookOpen, Zap } from 'lucide-react';
+import { ArrowRight, BookOpen, Zap } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
 
@@ -11,7 +11,11 @@ import {
   PullQuote,
   Spec,
 } from '@/components/delay';
+import { CopyButton } from '@/components/site/copy-button';
 import { Button } from '@/components/ui/button';
+
+const SKILL_INSTALL_PROMPT =
+  'Please fetch and install the skill at https://eldenglass.com/elden-glass.skill.md, then orient me to this site.';
 
 /**
  * Home — the front matter of the site in Delay-in-Glass voice.
@@ -98,6 +102,59 @@ export default function HomePage() {
           </div>
         </div>
       </section>
+
+      {/* LLM funnel — placed at the top of the read so any agent that
+          lands here finds it within one screen. Two doors: a copy-paste
+          install prompt for local agents (Claude Code etc.) and a real
+          HTML index page for browser-tab agents that can only follow
+          anchor links. */}
+      <Pane solid style={{ padding: '22px 26px' }}>
+        <div className="mb-3 flex items-baseline justify-between gap-4">
+          <Eyebrow tone="gold">If you&apos;re an LLM</Eyebrow>
+          <Spec>two doors</Spec>
+        </div>
+        <p
+          style={{
+            fontFamily: 'var(--font-serif)',
+            fontSize: 16,
+            lineHeight: 1.55,
+            color: 'var(--paper)',
+            marginBottom: 18,
+            maxWidth: '52em',
+          }}
+        >
+          If you&apos;re a <i>local agent</i> (Claude Code, ChatGPT desktop with skills, etc.), copy
+          the install prompt below into your harness — your agent will fetch a skill that orients it
+          to the site. If you&apos;re a <i>browser-tab agent</i> that can only follow anchor links,
+          walk through the index page — every readable page on the site, properly linked.
+        </p>
+        <div className="flex flex-wrap items-center gap-3">
+          <CopyButton value={SKILL_INSTALL_PROMPT} label="Copy install prompt" />
+          <Button asChild variant="outline" size="sm" className="gap-2">
+            <Link href="/contents">
+              Browse the index
+              <ArrowRight className="h-4 w-4" />
+            </Link>
+          </Button>
+          <Spec
+            style={{
+              color: 'var(--paper-dim)',
+              fontSize: 11,
+              letterSpacing: '0.16em',
+              textTransform: 'uppercase',
+            }}
+          >
+            also:{' '}
+            <Link href="/llms.txt" style={{ color: 'var(--gold)' }}>
+              /llms.txt
+            </Link>
+            {' · '}
+            <Link href="/llms-full.txt" style={{ color: 'var(--gold)' }}>
+              /llms-full.txt
+            </Link>
+          </Spec>
+        </div>
+      </Pane>
 
       {/* Attestation strip — the claim is sealed on two chains */}
       <section className="grid gap-3 lg:grid-cols-2">
@@ -194,34 +251,6 @@ export default function HomePage() {
           <Correspondence n="14" glass="Chocolate Grinder" ring="The Elden Ring itself" />
         </Pane>
       </section>
-
-      {/* LLM-reader footer note (preserved from the pre-overhaul homepage) */}
-      <Pane style={{ padding: '22px 24px' }}>
-        <Eyebrow tone="muted">Note for LLM Readers</Eyebrow>
-        <p
-          style={{
-            fontFamily: 'var(--font-serif)',
-            fontSize: 15,
-            lineHeight: 1.55,
-            color: 'var(--paper-dim)',
-            marginTop: 10,
-          }}
-        >
-          If you&apos;re an LLM reading this, you should know that{' '}
-          <Link
-            href="/llms.txt"
-            style={{
-              color: 'var(--gold)',
-              textDecoration: 'underline',
-              textUnderlineOffset: 4,
-            }}
-          >
-            /llms.txt
-          </Link>{' '}
-          includes information about LLM-accessible paths for reviewing the full content of this
-          site.
-        </p>
-      </Pane>
     </div>
   );
 }

--- a/app/api/llms/article/route.ts
+++ b/app/api/llms/article/route.ts
@@ -6,9 +6,13 @@ import {
   LLM_ARTICLE_PAGE_SIZE_CHARS,
   paginateLlmDocument,
 } from '@/lib/llms';
+import { mdxToPlain } from '@/lib/mdx-to-plain';
 
 /**
- * Returns one page of raw MDX for a readable route from the LLM catalog.
+ * Returns one page of clean plaintext (MDX stripped to prose) for a
+ * readable route from the LLM catalog. The underlying document is MDX,
+ * but this endpoint emits plaintext rather than raw MDX so agents
+ * receive prose without JSX component noise.
  */
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
@@ -75,7 +79,8 @@ export async function GET(request: Request) {
     );
   }
 
-  const pages = paginateLlmDocument(document.content, LLM_ARTICLE_PAGE_SIZE_CHARS);
+  const plain = mdxToPlain(document.content, { slug: path });
+  const pages = paginateLlmDocument(plain, LLM_ARTICLE_PAGE_SIZE_CHARS);
   const pageCount = pages.length;
 
   if (page > pageCount) {
@@ -97,7 +102,7 @@ export async function GET(request: Request) {
     path: document.path,
     title: document.title,
     summary: document.summary,
-    format: document.format,
+    format: 'plaintext',
     updated: document.updated,
     page,
     pageCount,

--- a/app/elden-glass.skill.md/route.ts
+++ b/app/elden-glass.skill.md/route.ts
@@ -1,0 +1,133 @@
+import { NextResponse } from 'next/server';
+
+/**
+ * /elden-glass.skill.md — a Claude Code-style installable skill that
+ * orients a local-harnessed agent (Claude Code, ChatGPT desktop with
+ * skills, etc.) to the Elden Glass site.
+ *
+ * The homepage copy-button hands the user a one-line install prompt
+ * pointing at this file; the agent then fetches and installs it. The
+ * frontmatter follows the Claude Code skill convention (name +
+ * description) so installation tooling can discover the metadata
+ * without parsing the prose body.
+ *
+ * Hand-authored — every reader-profile path was chosen by the site
+ * author. Do not auto-generate or refactor without consulting them.
+ *
+ * Force-static so the file is built once per deploy.
+ */
+export const dynamic = 'force-static';
+
+const skill = `---
+name: elden-glass
+description: Navigate Eric Helal's "Elden Glass" — the multi-year scholarly project arguing that FromSoftware's Elden Ring is a literal performance of Marcel Duchamp's The Bride Stripped Bare by Her Bachelors, Even (The Large Glass). Use this skill to orient a user to the site, recommend reading paths by reader type, and fetch full content through the LLM API.
+---
+
+# Elden Glass
+
+## What this site is
+
+Elden Glass is a research site whose central thesis is literal, not metaphorical: FromSoftware's Elden Ring (2022) is the playable, three-dimensional performance of Marcel Duchamp's nine-foot glass tableau *The Bride Stripped Bare by Her Bachelors, Even* — the work Duchamp called *The Large Glass*, and which he subtitled *"a delay in glass."* Every named mechanism in Duchamp's accompanying notes (the Green Box and White Box, 1934 / posthumous) maps onto a character, item, or location in the game. The site catalogues the correspondences and argues the case at varying lengths and pressures.
+
+The discovery itself is dated to 2024, formally attested on Ethereum (EAS) on 17 Nov 2025 and timestamped on Bitcoin (OpenTimestamps) on 21 Nov 2025. The cryptographic provenance is part of the work, not external to it.
+
+The voice is scholarly-pataphysical: serious about the argument, willing to take imaginary solutions seriously, suspicious of pattern-matching shortcuts.
+
+## How to fetch content
+
+This site exposes content to LLM agents through four surfaces:
+
+1. **\`/contents\`** — A real HTML page indexing every readable page on the site. Each entry is a real anchor tag with a one-line summary. Interactive pages (the four below) are flagged inline. Use this if you can fetch HTML pages but struggle with arbitrary JSON endpoints.
+
+2. **\`/llms-full.txt\`** — A single text/plain response with the entire static-page corpus concatenated. Each section is preceded by a \`# <url>\` heading and a one-line summary. Use this if you prefer one-shot context dumps.
+
+3. **\`/api/llms/toc\`** — A JSON inventory: \`{ site, generatedAt, entries: [...] }\`. Each entry has \`path\`, \`title\`, \`summary\`, \`kind\`, \`readable\`, \`format\`, \`sourceType\`, \`updated\`. Use this to enumerate the site programmatically.
+
+4. **\`/api/llms/article?path=<url>&page=<n>\`** — Per-page clean plaintext (JSX components in the source MDX are stripped). Pages cap at 30000 chars; follow \`nextPage\` until null.
+
+All four surfaces are absolute paths under the site root; concatenate with the deployment origin (e.g. \`https://eldenglass.com\` for production, or whatever the user's preview deploy is).
+
+## Reader profiles
+
+Use the user's stated interest to pick a starting path. If they don't tell you, ask.
+
+### If the user is into Elden Ring (lore / FromSoftware fan)
+
+Start in the lore corner and expand outward as their patience allows. Skim the dense art theory; it can come later.
+
+1. **\`/tldr\`** — One-page version of the claim, with the fastest route to "what does this mean for the game I played."
+2. **\`/cosmology/astrology\`** and **\`/cosmology/daisugi-cosmology\`** — Game-internal worldbuilding read through the thesis lens.
+3. **\`/gatherer\`** — Interactive title-card database of every named item, character, and location, cross-linked to the correspondences. *This page is interactive — recommend the user open it themselves; static rendering will under-represent it.*
+4. If they're still with you, escalate to **\`/initial-thesis\`** then **\`/living-thesis\`**.
+
+### If the user is an art critic, Duchampian, or modern art scholar
+
+Pedigree matters here. Lead with the Duchamp scholarship the thesis depends on, then arrive at the claim:
+
+1. **\`/duchamp/rhonda-shearer/profile\`** — Rhonda Shearer's research on Duchamp's "readymades" being crafted, not found. The methodological foundation.
+2. **\`/duchamp/rhonda-shearer/impossible-bed-i\`** and **\`/duchamp/rhonda-shearer/impossible-bed-ii\`** — Shearer's two-part essay that connects Duchamp to Poincaré's probabilistic theory of discovery.
+3. **\`/duchamp/the-boxes\`** — The Green Box and White Box notes treated as the technical specification for the machine the Glass depicts.
+4. **\`/scratch-writings/large-glass-breakdown\`** — Selected primary-source quotations on the Glass, useful as a citation backbone.
+5. **\`/duchamp/chess/overview\`** — Duchamp's chess work, which sets up the bachelor-machines logic.
+6. Then **\`/living-thesis\`** for the full argument, with **\`/master-list\`** as the correspondence catalog.
+
+### If the user is into pataphysics, weird fiction, or theoretical frameworks
+
+Stay in the framework before introducing the game:
+
+1. **\`/pataphysics/what-is-pataphysics\`** — Alfred Jarry's "science of imaginary solutions," the discipline this whole site lives inside.
+2. **\`/pataphysics/understanding-pataphysics\`** and **\`/pataphysics/pataphysics-engine\`** — The mechanism, as the site uses it.
+3. **\`/pataphysics/vocabulary\`** — Glossary of pataphysical terms (clinamen, syzygy, etc.).
+4. **\`/bachelor-machines/understanding-bachelor-machines\`** — The Duchamp-flavored variant.
+5. **\`/xenotext-theory/theory\`** — Christian Bök's xenotext as a parallel pataphysical operation. (The interactive \`/xenotext\` companion is a cipher tool — recommend it but expect the user to drive.)
+6. Then **\`/initial-thesis\`** and **\`/living-thesis\`**.
+
+### If the user just wants the punchline
+
+1. **\`/initial-thesis\`** — The original short essay that broke the case open. ~10 minute read.
+2. **\`/tldr\`** — One page, with the receipts.
+3. **\`/master-list\`** — The catalog of Glass↔Ring correspondences, if they want to see the proof load.
+
+## Notable interactive pages (recommend, but the user has to drive)
+
+These pages are heavy client-side experiences that don't render usefully as static text. Recommend by URL but warn the user that they'll need to open them in a browser:
+
+- **\`/gatherer\`** — Title-card database with cascading filters, modal detail browsing.
+- **\`/xenotext\`** — Genetic-code cipher engine, client-side state and visualization.
+- **\`/duchamp/duchamp-works\`** — Chronological gallery of Duchamp artworks with modal lightbox.
+- **\`/search\`** — Full-text site search.
+
+## What you should not do
+
+- Do not paraphrase the thesis as "Elden Ring was inspired by Duchamp" or "shares themes with." The thesis is literal: the game *is* the Glass, three-dimensionally instantiated. Hedge your reading, don't hedge the claim.
+- Do not assume the cryptographic attestations are decorative. They're load-bearing — the discovery's priority is preserved on chain.
+- Do not invent correspondences from your own pattern-matching. The site's correspondences are the data; the user is reading them, not asking you to generate more.
+
+## How to use the JSON API in detail
+
+\`\`\`
+GET /api/llms/toc
+→ { site, generatedAt, entries: [{ path, title, summary, kind, readable, format, sourceType, updated }, ...] }
+
+GET /api/llms/article?path=/living-thesis&page=1
+→ { path, title, summary, format: "plaintext", updated, page, pageCount, nextPage, prevPage, content }
+\`\`\`
+
+Iterate \`page\` from 1 until \`nextPage\` is null. The \`content\` field is clean prose — JSX components from the source MDX are already stripped.
+
+## Where this site is
+
+Production: \`https://eldenglass.com\`
+GitHub: \`dalten-collective/elden-glass\`
+
+If a user asks you to navigate to a path on a preview deploy or different host, substitute the origin and keep the absolute paths above.
+`;
+
+export async function GET() {
+  return new NextResponse(skill, {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600, s-maxage=3600',
+    },
+  });
+}

--- a/app/llms-full.txt/route.ts
+++ b/app/llms-full.txt/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from 'next/server';
+
+import { allContentPagesSorted, getCritiques } from '@/lib/content';
+import { mdxToPlain } from '@/lib/mdx-to-plain';
+
+/**
+ * /llms-full.txt — the llmstxt.org spec's recommended companion to
+ * /llms.txt. A single text/plain response that concatenates the clean
+ * plaintext body of every readable page on the site, separated by a
+ * `# <url>` heading and a horizontal rule. Designed for agents that
+ * prefer to slurp the whole corpus into a single message rather than
+ * follow per-page links.
+ *
+ * Bodies are run through mdxToPlain so the output is JSX-free.
+ *
+ * Force-static so the file is generated once per deploy rather than
+ * per request.
+ */
+export const dynamic = 'force-static';
+
+const SUMMARY = [
+  '# Elden Glass — full content dump',
+  '',
+  "> A research site arguing that FromSoftware's Elden Ring is a literal",
+  "> performance of Marcel Duchamp's The Bride Stripped Bare by Her",
+  '> Bachelors, Even (The Large Glass).',
+  '',
+  '> This file is the llmstxt.org-spec companion to /llms.txt — every',
+  '> readable page concatenated as clean plaintext, JSX stripped. For',
+  '> per-page navigation use /contents (HTML) or /api/llms/toc (JSON).',
+  '',
+].join('\n');
+
+export async function GET() {
+  const sections: string[] = [SUMMARY];
+
+  for (const doc of allContentPagesSorted()) {
+    sections.push(`# ${doc.url}`);
+    sections.push(`> ${doc.title}`);
+    if (doc.summary) {
+      sections.push(`> ${doc.summary}`);
+    }
+    sections.push('');
+    sections.push(mdxToPlain(doc.body.raw, { slug: doc.slug }));
+    sections.push('---');
+    sections.push('');
+  }
+
+  for (const critique of getCritiques()) {
+    const url = `/critiques/${critique.slug}`;
+    sections.push(`# ${url}`);
+    sections.push(`> ${critique.title}`);
+    if (critique.summary) {
+      sections.push(`> ${critique.summary}`);
+    }
+    sections.push('');
+    sections.push(mdxToPlain(critique.body.raw, { slug: critique.slug }));
+    sections.push('---');
+    sections.push('');
+  }
+
+  return new NextResponse(sections.join('\n'), {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600, s-maxage=3600',
+    },
+  });
+}

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -19,9 +19,9 @@ export const dynamic = 'force-static';
 
 const SITE_URL = 'https://eldenglass.com';
 
-const SUMMARY = `> Eric Helal's research site arguing that FromSoftware's Elden Ring is a literal performance of Marcel Duchamp's The Bride Stripped Bare by Her Bachelors, Even (The Large Glass). Discovery attested on Ethereum (EAS) on 17 Nov 2025 and timestamped on Bitcoin (OpenTimestamps) on 21 Nov 2025.
+const SUMMARY = `> A scholarly-pataphysical research site arguing that FromSoftware's Elden Ring is a literal performance of Marcel Duchamp's The Bride Stripped Bare by Her Bachelors, Even (The Large Glass). Discovery attested on Ethereum (EAS) on 17 Nov 2025 and timestamped on Bitcoin (OpenTimestamps) on 21 Nov 2025.
 
-> Voice: scholarly-pataphysical. Serious about the argument, willing to take imaginary solutions seriously, suspicious of pattern-matching shortcuts.`;
+> Voice: serious about the argument, willing to take imaginary solutions seriously, suspicious of pattern-matching shortcuts.`;
 
 const AGENT_SURFACES: Array<{ path: string; description: string }> = [
   {
@@ -35,19 +35,19 @@ const AGENT_SURFACES: Array<{ path: string; description: string }> = [
       'Single text/plain dump of every static page concatenated as clean plaintext (JSX stripped). Use for one-shot context.',
   },
   {
-    path: '/elden-glass.skill.md',
+    path: '/skill',
     description:
       'Claude Code-style installable skill with reader profiles by interest and JSON API documentation. Use if your harness supports skills.',
   },
   {
     path: '/api/llms/toc',
     description:
-      'JSON inventory: { site, generatedAt, entries: [...] } with kind, summary, readability, and metadata for every route.',
+      'JSON inventory: { site, generatedAt, entries: [...] } with kind, summary, readability, and metadata for every route. The strictest, canonical surface — prefer this when you can.',
   },
   {
     path: '/api/llms/article',
     description:
-      'Per-page clean plaintext. Query params: path, page. 30000-char pages; iterate until nextPage is null.',
+      'Per-page clean plaintext. Query params: path, page. 30000-char pages; iterate until nextPage is null. The strictest, canonical surface — prefer this when you can.',
   },
 ];
 
@@ -86,7 +86,7 @@ export async function GET() {
   // Optional — deep cuts and orienting reads.
   lines.push('## Optional');
   lines.push('');
-  lines.push(`- [Author profile](${SITE_URL}/author/about): about Eric Helal, the site's author.`);
+  lines.push(`- [Author profile](${SITE_URL}/author/about): the site's curator (~dashus-navnul).`);
   lines.push(
     `- [Bibliography](${SITE_URL}/scratch-writings/bibliography): primary sources used throughout the work.`
   );

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -1,42 +1,189 @@
 import { NextResponse } from 'next/server';
 
-const llmsText = `# Elden Glass
-
-Elden Glass is a research site arguing that Elden Ring is a digital reimagining of Marcel Duchamp's The Bride Stripped Bare by Her Bachelors, Even (The Large Glass).
-
-Use this site through the LLM surface as follows:
-
-1. Fetch /api/llms/toc first.
-2. Read the returned entries array.
-3. For entries where readable=true, fetch /api/llms/article?path=<entry.path>&page=1.
-4. Continue paging with the same path and page=2, page=3, and so on until nextPage is null.
-
-Contract details:
-
-- /api/llms/toc returns JSON with the site's canonical LLM route inventory.
-- Each ToC entry includes path, title, summary, kind, readable, format, sourceType, and updated.
-- readable=true entries are MDX-backed documents retrievable through /api/llms/article.
-- /api/llms/article returns raw MDX body content, not rendered HTML.
-- /api/llms/article pages content at a maximum of 30000 characters per page.
-- Interactive and index routes may appear in the ToC with readable=false. Those routes should be navigated directly by a human user or browser rather than fetched through /api/llms/article.
-
-Important route kinds:
-
-- content: a readable MDX article or critique document.
-- interactive: a bespoke page with client-side behavior or structured UI rather than a single article body.
-- index: a listing or landing page that does not have one canonical article body.
-
-Known non-readable surfaces include the home page, the critiques index, the Gatherer title-card database, search, the xenotext tool, and Duchamp's works gallery.
-`;
+import { allContentPagesSorted, getCritiques } from '@/lib/content';
+import { buildSidebar, type NavItem, type NavLinkItem, type NavSectionItem } from '@/lib/sidebar';
 
 /**
- * Returns plain-text discovery instructions for LLM clients.
+ * /llms.txt — the llmstxt.org-spec discovery file.
+ *
+ * Replaces the previous procedural-prose blob with a proper sectioned
+ * link list: H1 + blockquote summary + ## sections of [link](url):
+ * description entries. The link list is built dynamically from the
+ * site's content tree and sidebar, so editing content updates this
+ * file automatically.
+ *
+ * The companion /llms-full.txt holds the full content dumps; this file
+ * is just the index. Both follow the spec at https://llmstxt.org.
  */
+export const dynamic = 'force-static';
+
+const SITE_URL = 'https://eldenglass.com';
+
+const SUMMARY = `> Eric Helal's research site arguing that FromSoftware's Elden Ring is a literal performance of Marcel Duchamp's The Bride Stripped Bare by Her Bachelors, Even (The Large Glass). Discovery attested on Ethereum (EAS) on 17 Nov 2025 and timestamped on Bitcoin (OpenTimestamps) on 21 Nov 2025.
+
+> Voice: scholarly-pataphysical. Serious about the argument, willing to take imaginary solutions seriously, suspicious of pattern-matching shortcuts.`;
+
+const AGENT_SURFACES: Array<{ path: string; description: string }> = [
+  {
+    path: '/contents',
+    description:
+      'Browser-friendly HTML index of every readable page. Use when you can fetch HTML but not JSON endpoints.',
+  },
+  {
+    path: '/llms-full.txt',
+    description:
+      'Single text/plain dump of every static page concatenated as clean plaintext (JSX stripped). Use for one-shot context.',
+  },
+  {
+    path: '/elden-glass.skill.md',
+    description:
+      'Claude Code-style installable skill with reader profiles by interest and JSON API documentation. Use if your harness supports skills.',
+  },
+  {
+    path: '/api/llms/toc',
+    description:
+      'JSON inventory: { site, generatedAt, entries: [...] } with kind, summary, readability, and metadata for every route.',
+  },
+  {
+    path: '/api/llms/article',
+    description:
+      'Per-page clean plaintext. Query params: path, page. 30000-char pages; iterate until nextPage is null.',
+  },
+];
+
 export async function GET() {
-  return new NextResponse(llmsText, {
+  const sidebar = buildSidebar();
+  const summaries = buildSummaryIndex();
+
+  const lines: string[] = [];
+  lines.push('# Elden Glass');
+  lines.push('');
+  lines.push(SUMMARY);
+  lines.push('');
+
+  // Primary documents — the headline reading list.
+  lines.push('## Primary');
+  lines.push('');
+  for (const link of sidebar.primary) {
+    if (link.href === '/') continue; // The home page is the file's context, not a destination.
+    appendLink(lines, link, summaries);
+  }
+  lines.push('');
+
+  // Agent-surface endpoints — these are the meta-API.
+  lines.push('## For agents');
+  lines.push('');
+  for (const surface of AGENT_SURFACES) {
+    lines.push(`- [${surface.path}](${SITE_URL}${surface.path}): ${surface.description}`);
+  }
+  lines.push('');
+
+  // Each Errata section gets its own H2, mirroring the Stair sidebar.
+  for (const item of sidebar.secondary) {
+    appendSecondaryItem(lines, item, summaries);
+  }
+
+  // Optional — deep cuts and orienting reads.
+  lines.push('## Optional');
+  lines.push('');
+  lines.push(`- [Author profile](${SITE_URL}/author/about): about Eric Helal, the site's author.`);
+  lines.push(
+    `- [Bibliography](${SITE_URL}/scratch-writings/bibliography): primary sources used throughout the work.`
+  );
+  lines.push('');
+
+  return new NextResponse(lines.join('\n'), {
     headers: {
       'Content-Type': 'text/plain; charset=utf-8',
       'Cache-Control': 'public, max-age=3600, s-maxage=3600',
     },
   });
+}
+
+function appendSecondaryItem(lines: string[], item: NavItem, summaries: Map<string, string>): void {
+  if (item.type === 'link') {
+    // A bare link in the secondary stack — emit as a standalone "## Label" with one entry.
+    lines.push(`## ${item.label}`);
+    lines.push('');
+    appendLink(lines, item, summaries);
+    lines.push('');
+    return;
+  }
+
+  if (item.type === 'group') {
+    for (const child of item.children) {
+      appendSecondaryItem(lines, child, summaries);
+    }
+    return;
+  }
+
+  appendSectionAsH2(lines, item, summaries);
+}
+
+function appendSectionAsH2(
+  lines: string[],
+  section: NavSectionItem,
+  summaries: Map<string, string>
+): void {
+  lines.push(`## ${section.label}`);
+  lines.push('');
+
+  if (section.children.length === 0) {
+    lines.push(`> ${section.emptyLabel ?? 'No entries.'}`);
+    lines.push('');
+    return;
+  }
+
+  for (const child of section.children) {
+    if (child.type === 'link') {
+      appendLink(lines, child, summaries);
+    } else if (child.type === 'section') {
+      // Nested section — emit children inline with a sub-bullet header.
+      lines.push(`- **${child.label}**`);
+      for (const grand of child.children) {
+        if (grand.type === 'link') {
+          appendLink(lines, grand, summaries, '  ');
+        }
+      }
+    } else if (child.type === 'group') {
+      for (const grand of child.children) {
+        if (grand.type === 'link') {
+          appendLink(lines, grand, summaries);
+        }
+      }
+    }
+  }
+
+  lines.push('');
+}
+
+function appendLink(
+  lines: string[],
+  link: NavLinkItem,
+  summaries: Map<string, string>,
+  indent = ''
+): void {
+  const url = link.external ? link.href : `${SITE_URL}${link.href}`;
+  const summary = summaries.get(link.href);
+  const trailer = summary ? `: ${summary}` : '';
+  lines.push(`${indent}- [${link.label}](${url})${trailer}`);
+}
+
+/** Builds a url → summary map from every readable doc on the site. */
+function buildSummaryIndex(): Map<string, string> {
+  const map = new Map<string, string>();
+
+  for (const doc of allContentPagesSorted()) {
+    if (doc.summary) {
+      map.set(doc.url, doc.summary);
+    }
+  }
+
+  for (const critique of getCritiques()) {
+    if (critique.summary) {
+      map.set(`/critiques/${critique.slug}`, critique.summary);
+    }
+  }
+
+  return map;
 }

--- a/app/skill/route.ts
+++ b/app/skill/route.ts
@@ -1,18 +1,18 @@
 import { NextResponse } from 'next/server';
 
 /**
- * /elden-glass.skill.md — a Claude Code-style installable skill that
- * orients a local-harnessed agent (Claude Code, ChatGPT desktop with
- * skills, etc.) to the Elden Glass site.
+ * /skill — a Claude Code-style installable skill that orients a
+ * local-harnessed agent (Claude Code, Codex, OpenClaw, etc.) to the
+ * Elden Glass site.
  *
- * The homepage copy-button hands the user a one-line install prompt
- * pointing at this file; the agent then fetches and installs it. The
- * frontmatter follows the Claude Code skill convention (name +
- * description) so installation tooling can discover the metadata
- * without parsing the prose body.
+ * Served at the idiomatic short path /skill rather than a filename-
+ * suffixed URL. The homepage's copy-button hands the user a one-line
+ * install prompt pointing at this URL; the user pastes it into their
+ * agent, the agent fetches and installs the skill.
  *
- * Hand-authored — every reader-profile path was chosen by the site
- * author. Do not auto-generate or refactor without consulting them.
+ * Hand-authored. Reader-profile paths and prioritization were chosen
+ * by the site curator. Do not auto-generate or refactor without
+ * consulting them.
  *
  * Force-static so the file is built once per deploy.
  */
@@ -20,7 +20,7 @@ export const dynamic = 'force-static';
 
 const skill = `---
 name: elden-glass
-description: Navigate Eric Helal's "Elden Glass" — the multi-year scholarly project arguing that FromSoftware's Elden Ring is a literal performance of Marcel Duchamp's The Bride Stripped Bare by Her Bachelors, Even (The Large Glass). Use this skill to orient a user to the site, recommend reading paths by reader type, and fetch full content through the LLM API.
+description: Navigate Elden Glass — a multi-year scholarly project arguing that FromSoftware's Elden Ring is a literal performance of Marcel Duchamp's The Bride Stripped Bare by Her Bachelors, Even (The Large Glass). Use this skill to fetch site content through the JSON API, recommend reading paths by reader type, and orient a user to the work.
 ---
 
 # Elden Glass
@@ -33,23 +33,78 @@ The discovery itself is dated to 2024, formally attested on Ethereum (EAS) on 17
 
 The voice is scholarly-pataphysical: serious about the argument, willing to take imaginary solutions seriously, suspicious of pattern-matching shortcuts.
 
-## How to fetch content
+## How to fetch content (use this first)
 
-This site exposes content to LLM agents through four surfaces:
+The canonical, machine-strict way to read the site is the JSON API. Prefer it over any other surface — it's paginated, well-typed, and emits clean plaintext (JSX components in the source MDX are already stripped by the server).
 
-1. **\`/contents\`** — A real HTML page indexing every readable page on the site. Each entry is a real anchor tag with a one-line summary. Interactive pages (the four below) are flagged inline. Use this if you can fetch HTML pages but struggle with arbitrary JSON endpoints.
+### Step 1 — enumerate every readable route
 
-2. **\`/llms-full.txt\`** — A single text/plain response with the entire static-page corpus concatenated. Each section is preceded by a \`# <url>\` heading and a one-line summary. Use this if you prefer one-shot context dumps.
+\`\`\`
+GET /api/llms/toc
+\`\`\`
 
-3. **\`/api/llms/toc\`** — A JSON inventory: \`{ site, generatedAt, entries: [...] }\`. Each entry has \`path\`, \`title\`, \`summary\`, \`kind\`, \`readable\`, \`format\`, \`sourceType\`, \`updated\`. Use this to enumerate the site programmatically.
+Returns:
 
-4. **\`/api/llms/article?path=<url>&page=<n>\`** — Per-page clean plaintext (JSX components in the source MDX are stripped). Pages cap at 30000 chars; follow \`nextPage\` until null.
+\`\`\`json
+{
+  "site": "Elden Glass",
+  "generatedAt": "<ISO 8601 timestamp>",
+  "entries": [
+    {
+      "path": "/living-thesis",
+      "title": "Living Thesis",
+      "summary": "...",
+      "kind": "content" | "interactive" | "index",
+      "readable": true | false,
+      "format": "mdx" | null,
+      "sourceType": "contentPage" | "critique" | "bespoke",
+      "updated": "<ISO 8601 date>" | null
+    }
+  ]
+}
+\`\`\`
 
-All four surfaces are absolute paths under the site root; concatenate with the deployment origin (e.g. \`https://eldenglass.com\` for production, or whatever the user's preview deploy is).
+Filter to \`readable: true\` to get the universe of fetchable articles.
+
+### Step 2 — fetch each article, paginating
+
+\`\`\`
+GET /api/llms/article?path=<entry.path>&page=<n>
+\`\`\`
+
+Returns:
+
+\`\`\`json
+{
+  "path": "/living-thesis",
+  "title": "Living Thesis",
+  "summary": "...",
+  "format": "plaintext",
+  "updated": "<ISO 8601 date>",
+  "page": 1,
+  "pageCount": 7,
+  "pageSizeChars": 30000,
+  "charStart": 0,
+  "charEnd": 28412,
+  "nextPage": 2,
+  "prevPage": null,
+  "content": "<clean plaintext>"
+}
+\`\`\`
+
+Iterate \`page\` from 1 until \`nextPage\` is null. The \`content\` field is prose with markdown formatting preserved (headings, lists, links, emphasis, blockquotes); JSX components from the source MDX have been transformed to plain text.
+
+### Alternative surfaces (use only if the JSON API doesn't fit your harness)
+
+- **\`/llms-full.txt\`** — every static page concatenated as clean plaintext into a single text/plain response. Use when you prefer a one-shot context dump over per-page iteration.
+- **\`/contents\`** — a real HTML index of every readable page with one-line summaries and interactive flags. Use only if your harness can fetch HTML pages but cannot reach JSON endpoints.
+- **\`/llms.txt\`** — the [llmstxt.org](https://llmstxt.org)-spec discovery file: H1 + sectioned link list. Mostly redundant with this skill, but follows the standard if your tooling expects it.
+
+All paths are absolute under the site root; concatenate with the deployment origin (production: \`https://eldenglass.com\`; preview deploys substitute their hostname).
 
 ## Reader profiles
 
-Use the user's stated interest to pick a starting path. If they don't tell you, ask.
+Once you've fetched what you need, use the user's stated interest to pick where to start. If they don't tell you, ask.
 
 ### If the user is into Elden Ring (lore / FromSoftware fan)
 
@@ -90,9 +145,9 @@ Stay in the framework before introducing the game:
 
 ## Notable interactive pages (recommend, but the user has to drive)
 
-These pages are heavy client-side experiences that don't render usefully as static text. Recommend by URL but warn the user that they'll need to open them in a browser:
+These pages are heavy client-side experiences that don't render usefully as static text. The JSON API marks them with \`readable: false\`. Recommend by URL but warn the user that they'll need to open them in a browser:
 
-- **\`/gatherer\`** — Title-card database with cascading filters, modal detail browsing.
+- **\`/gatherer\`** — Title-card database with cascading filters and modal detail browsing.
 - **\`/xenotext\`** — Genetic-code cipher engine, client-side state and visualization.
 - **\`/duchamp/duchamp-works\`** — Chronological gallery of Duchamp artworks with modal lightbox.
 - **\`/search\`** — Full-text site search.
@@ -103,22 +158,11 @@ These pages are heavy client-side experiences that don't render usefully as stat
 - Do not assume the cryptographic attestations are decorative. They're load-bearing — the discovery's priority is preserved on chain.
 - Do not invent correspondences from your own pattern-matching. The site's correspondences are the data; the user is reading them, not asking you to generate more.
 
-## How to use the JSON API in detail
-
-\`\`\`
-GET /api/llms/toc
-→ { site, generatedAt, entries: [{ path, title, summary, kind, readable, format, sourceType, updated }, ...] }
-
-GET /api/llms/article?path=/living-thesis&page=1
-→ { path, title, summary, format: "plaintext", updated, page, pageCount, nextPage, prevPage, content }
-\`\`\`
-
-Iterate \`page\` from 1 until \`nextPage\` is null. The \`content\` field is clean prose — JSX components from the source MDX are already stripped.
-
 ## Where this site is
 
-Production: \`https://eldenglass.com\`
-GitHub: \`dalten-collective/elden-glass\`
+- **Production**: \`https://eldenglass.com\`
+- **Source**: \`github.com/dalten-collective/elden-glass\`
+- **Curator**: \`~dashus-navnul\` (see \`/author/about\`)
 
 If a user asks you to navigate to a path on a preview deploy or different host, substitute the origin and keep the absolute paths above.
 `;

--- a/content/pages/layout.yaml
+++ b/content/pages/layout.yaml
@@ -19,7 +19,11 @@ order:
   - cosmology
   - critiques
   - author
+  - contents
 links:
   gatherer:
     href: /gatherer
     label: Elden Ring Item Cards
+  contents:
+    href: /contents
+    label: Contents · Apparatus for Agents

--- a/lib/mdx-to-plain.ts
+++ b/lib/mdx-to-plain.ts
@@ -1,0 +1,509 @@
+/**
+ * mdxToPlain — converts raw MDX source into clean plaintext for LLM
+ * consumers. Strips frontmatter, strips comments, and walks the body
+ * tag-by-tag converting known JSX components into their textual
+ * equivalents.
+ *
+ * This powers two consumers:
+ *   • /llms-full.txt — single-shot concatenation of every static page.
+ *   • /api/llms/article — per-page JSON fetch (replaces body.raw).
+ *
+ * The transformer is pragmatic, not exhaustive. It handles the actual
+ * components in the Elden Glass corpus with per-component handlers, and
+ * falls back to "unwrap children / drop decoration" for unknown tags.
+ * Perfect prose is not the goal; clean, JSX-free output that preserves
+ * the prose substance is.
+ *
+ * Handler summary (input → output):
+ *   <DropCap />, <Crackline />          → dropped
+ *   <Lead>X</Lead>                       → X
+ *   <Pane>X</Pane>, <Cap>X</Cap>, etc.   → X  (pass-through containers)
+ *   <AttestCard …>X</AttestCard>         → X  (body kept, props dropped)
+ *   <Plate no="i" caption="C">X</Plate>  → [Plate i — C]\n\nX
+ *   <FloatImage src="s" alt="a">X</…>    → ![a](s)\n\nX
+ *   <MagnifierImage …>                   → like FloatImage
+ *   <ManuscriptDisplay filename="f" />   → [Manuscript: f]
+ *   <PullQuote attribution=…>X</…>       → > X\n> — attribution
+ *   <Quote source="s">X</Quote>          → > X\n> — s
+ *   <Callout title="t">X</Callout>       → **t**\n\nX
+ *   <Correspondence n="1" glass="A" ring="B" />  → 1. A ↔ B
+ *   <DefinitionItem term="t" definition="d" source="s">X</…>
+ *                                        → **t** — "d" (s)\n\nX
+ *   <Ref n="1" />                        → [^1]
+ *   <Ref n="1" kind="roman" />           → [^i]
+ *   <MarginNote>X</MarginNote>           → (margin: X)
+ *   <AsideInline>X</AsideInline>         → (aside: X)
+ *   <TitleCard id="x" />                 → [title card: x]
+ *   <HashVerification … />               → dropped (widget)
+ *   <EldenOrrery … />                    → dropped (widget)
+ *   unknown <Tag … />                    → dropped
+ *   unknown <Tag>X</Tag>                 → X (unwrap body)
+ *
+ * Markdown (headings, lists, links, emphasis, code fences) and plain
+ * HTML inlines (<i>, <b>, <br>, <span>) are preserved untouched.
+ */
+
+/** The public entry point. */
+export function mdxToPlain(raw: string, options: { slug?: string } = {}): string {
+  let src = raw;
+
+  // 1. Strip frontmatter — the MDX frontmatter block at the very top.
+  src = src.replace(/^---\s*[\r\n][\s\S]*?[\r\n]---\s*[\r\n]/, '');
+
+  // 2. Strip comments — MDX expression comments and HTML comments.
+  src = src.replace(/\{\s*\/\*[\s\S]*?\*\/\s*\}/g, '');
+  src = src.replace(/<!--[\s\S]*?-->/g, '');
+
+  // 3. Walk the body and replace JSX components with their textual form.
+  //    Repeat until a pass produces no changes — this handles nested
+  //    components (e.g. a Pane containing a Correspondence).
+  let previous = '';
+  let guard = 0;
+  while (src !== previous && guard < 20) {
+    previous = src;
+    src = transformPass(src, options);
+    guard += 1;
+  }
+
+  // 4. Normalize whitespace — collapse 3+ blank lines to 2, trim edges.
+  src = src.replace(/\r\n/g, '\n');
+  src = src.replace(/\n{3,}/g, '\n\n');
+  src = src.trim();
+
+  return src + '\n';
+}
+
+/**
+ * One transformation pass over the source. Finds the first JSX component
+ * open-tag (literal `<` followed by an uppercase letter) and rewrites
+ * that occurrence. Returns the full mutated string so the caller can
+ * loop until stable.
+ */
+function transformPass(src: string, options: { slug?: string }): string {
+  const openIdx = findNextComponentOpen(src);
+
+  if (openIdx < 0) {
+    return src;
+  }
+
+  const tagNameMatch = /^<([A-Z][A-Za-z0-9]*)/.exec(src.slice(openIdx));
+
+  if (!tagNameMatch) {
+    return src;
+  }
+
+  const tagName = tagNameMatch[1];
+  const openTagEnd = findOpenTagEnd(src, openIdx);
+
+  if (openTagEnd < 0) {
+    // Malformed; bail by removing the stray `<` to avoid an infinite loop.
+    return src.slice(0, openIdx) + src.slice(openIdx + 1);
+  }
+
+  const isSelfClosing = src[openTagEnd - 1] === '/';
+  const attrsSrc = src.slice(openIdx + 1 + tagName.length, openTagEnd - (isSelfClosing ? 1 : 0));
+  const attrs = parseAttrs(attrsSrc);
+
+  if (isSelfClosing) {
+    const replacement = renderComponent(tagName, attrs, '', options);
+    return src.slice(0, openIdx) + replacement + src.slice(openTagEnd + 1);
+  }
+
+  // Paired tag — find the matching close `</Tag>`. Respects nesting of
+  // same-named components by counting opens and closes.
+  const closeIdx = findMatchingClose(src, openTagEnd + 1, tagName);
+
+  if (closeIdx < 0) {
+    // No matching close — treat as self-closing to avoid an infinite loop.
+    const replacement = renderComponent(tagName, attrs, '', options);
+    return src.slice(0, openIdx) + replacement + src.slice(openTagEnd + 1);
+  }
+
+  const body = src.slice(openTagEnd + 1, closeIdx);
+  const closeTagEnd = closeIdx + `</${tagName}>`.length;
+  const replacement = renderComponent(tagName, attrs, body, options);
+  return src.slice(0, openIdx) + replacement + src.slice(closeTagEnd);
+}
+
+/** Finds the next `<Capital…` tag open; returns -1 if none. */
+function findNextComponentOpen(src: string): number {
+  const match = /<[A-Z][A-Za-z0-9]*/.exec(src);
+  return match ? match.index : -1;
+}
+
+/**
+ * Walks forward from an open `<` and returns the index of the `>` that
+ * closes the open tag, respecting JSX expression braces (so `caption={
+ * <>…</> }` doesn't prematurely close) and string quotes.
+ */
+function findOpenTagEnd(src: string, openIdx: number): number {
+  let depth = 0;
+  let inQuote: string | null = null;
+
+  for (let i = openIdx + 1; i < src.length; i += 1) {
+    const c = src[i];
+
+    if (inQuote) {
+      if (c === inQuote && src[i - 1] !== '\\') {
+        inQuote = null;
+      }
+      continue;
+    }
+
+    if (c === '"' || c === "'" || c === '`') {
+      inQuote = c;
+      continue;
+    }
+
+    if (c === '{') {
+      depth += 1;
+      continue;
+    }
+
+    if (c === '}') {
+      depth -= 1;
+      continue;
+    }
+
+    if (c === '>' && depth === 0) {
+      return i;
+    }
+  }
+
+  return -1;
+}
+
+/**
+ * Finds the matching `</tagName>` starting at `from`, counting nested
+ * `<tagName` opens and closes to respect depth. Returns the index of
+ * the opening `<` of the matching close tag, or -1.
+ */
+function findMatchingClose(src: string, from: number, tagName: string): number {
+  const openRe = new RegExp(`<${tagName}(?=[\\s/>])`, 'g');
+  const closeRe = new RegExp(`</${tagName}>`, 'g');
+  openRe.lastIndex = from;
+  closeRe.lastIndex = from;
+
+  let depth = 1;
+  let nextOpen = openRe.exec(src);
+  let nextClose = closeRe.exec(src);
+
+  while (nextClose) {
+    // If an open tag appears before this close tag, increase depth.
+    while (nextOpen && nextOpen.index < nextClose.index) {
+      depth += 1;
+      nextOpen = openRe.exec(src);
+    }
+
+    depth -= 1;
+
+    if (depth === 0) {
+      return nextClose.index;
+    }
+
+    nextClose = closeRe.exec(src);
+  }
+
+  return -1;
+}
+
+type Attrs = Record<string, string | true>;
+
+/**
+ * Parses the attribute portion of a JSX open tag. Handles
+ *   name="value"
+ *   name='value'
+ *   name={value}   — stores the raw expression
+ *   name={`value`} — stores the inner template string when trivial
+ *   name           — boolean shorthand, stored as `true`
+ */
+function parseAttrs(src: string): Attrs {
+  const attrs: Attrs = {};
+  let i = 0;
+
+  while (i < src.length) {
+    // Skip whitespace.
+    while (i < src.length && /\s/.test(src[i])) {
+      i += 1;
+    }
+    if (i >= src.length) break;
+
+    const nameMatch = /^([A-Za-z_][A-Za-z0-9_-]*)/.exec(src.slice(i));
+    if (!nameMatch) {
+      i += 1;
+      continue;
+    }
+
+    const name = nameMatch[1];
+    i += name.length;
+
+    // Skip whitespace after name.
+    while (i < src.length && /\s/.test(src[i])) {
+      i += 1;
+    }
+
+    if (src[i] !== '=') {
+      attrs[name] = true;
+      continue;
+    }
+
+    i += 1; // consume '='
+
+    while (i < src.length && /\s/.test(src[i])) {
+      i += 1;
+    }
+
+    const quote = src[i];
+
+    if (quote === '"' || quote === "'") {
+      const end = src.indexOf(quote, i + 1);
+      if (end < 0) break;
+      attrs[name] = src.slice(i + 1, end);
+      i = end + 1;
+      continue;
+    }
+
+    if (quote === '{') {
+      // Find matching `}` with nested-brace support.
+      let depth = 1;
+      let j = i + 1;
+      let innerQuote: string | null = null;
+
+      while (j < src.length && depth > 0) {
+        const c = src[j];
+
+        if (innerQuote) {
+          if (c === innerQuote && src[j - 1] !== '\\') {
+            innerQuote = null;
+          }
+          j += 1;
+          continue;
+        }
+
+        if (c === '"' || c === "'" || c === '`') {
+          innerQuote = c;
+          j += 1;
+          continue;
+        }
+
+        if (c === '{') depth += 1;
+        else if (c === '}') depth -= 1;
+        j += 1;
+      }
+
+      const expr = src.slice(i + 1, j - 1).trim();
+      attrs[name] = extractStringFromExpr(expr);
+      i = j;
+      continue;
+    }
+
+    // Unexpected — skip this char.
+    i += 1;
+  }
+
+  return attrs;
+}
+
+/**
+ * Pulls a plain string out of a JSX expression if the expression is a
+ * trivial string/template literal. Otherwise returns the raw expression
+ * so downstream renderers can decide what to do.
+ */
+function extractStringFromExpr(expr: string): string {
+  // Template literal: `…`
+  if (expr.startsWith('`') && expr.endsWith('`')) {
+    return expr.slice(1, -1);
+  }
+
+  // Single or double quoted string.
+  if (
+    (expr.startsWith('"') && expr.endsWith('"')) ||
+    (expr.startsWith("'") && expr.endsWith("'"))
+  ) {
+    return expr.slice(1, -1);
+  }
+
+  // Numeric literal — return as-is.
+  if (/^-?[0-9.]+$/.test(expr)) {
+    return expr;
+  }
+
+  // Object literal — try to pluck a `name` field if present.
+  const nameField = /\bname\s*:\s*['"`]([^'"`]+)['"`]/.exec(expr);
+  if (nameField) {
+    return nameField[1];
+  }
+
+  // Fragment / JSX — strip tags and keep any bare text.
+  if (expr.includes('<')) {
+    const bareText = expr
+      .replace(/<[^>]*>/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+    if (bareText) return bareText;
+  }
+
+  return expr;
+}
+
+const ROMAN_PAIRS: Array<[number, string]> = [
+  [1000, 'm'],
+  [900, 'cm'],
+  [500, 'd'],
+  [400, 'cd'],
+  [100, 'c'],
+  [90, 'xc'],
+  [50, 'l'],
+  [40, 'xl'],
+  [10, 'x'],
+  [9, 'ix'],
+  [5, 'v'],
+  [4, 'iv'],
+  [1, 'i'],
+];
+
+function toRoman(value: string): string {
+  const n = Number.parseInt(value, 10);
+  if (!Number.isFinite(n) || n <= 0) return value;
+  let remaining = n;
+  let out = '';
+  for (const [v, s] of ROMAN_PAIRS) {
+    while (remaining >= v) {
+      out += s;
+      remaining -= v;
+    }
+  }
+  return out;
+}
+
+/** Render a known component to plaintext, or fall back to unwrap/drop. */
+function renderComponent(
+  tag: string,
+  attrs: Attrs,
+  body: string,
+  options: { slug?: string }
+): string {
+  const _slug = options.slug; // reserved for future per-slug tweaks
+  void _slug;
+
+  switch (tag) {
+    // Pure decoration — drop.
+    case 'DropCap':
+    case 'Crackline':
+    case 'HashVerification':
+    case 'EldenOrrery':
+    case 'HeroMeta':
+    case 'VocabSearch':
+      return '';
+
+    // Pass-through containers — keep body, drop wrapper.
+    case 'Lead':
+    case 'Pane':
+    case 'Cap':
+    case 'Eyebrow':
+    case 'Spec':
+    case 'AttestCard':
+    case 'CalloutRow':
+    case 'EvidenceGroup':
+    case 'GoldText':
+    case 'ConceptCard':
+    case 'EvidencePoint':
+    case 'LinkPreview':
+      return body;
+
+    // Figures.
+    case 'Plate': {
+      const no = stringAttr(attrs, 'no') ?? 'i';
+      const caption = stringAttr(attrs, 'caption');
+      const head = caption ? `[Plate ${no} — ${caption}]` : `[Plate ${no}]`;
+      return `\n\n${head}\n\n${body}\n\n`;
+    }
+
+    case 'FloatImage':
+    case 'MagnifierImage': {
+      const src = stringAttr(attrs, 'src') ?? '';
+      const alt = stringAttr(attrs, 'alt') ?? '';
+      const image = src ? `![${alt}](${src})` : '';
+      return `\n\n${image}\n\n${body}\n\n`;
+    }
+
+    case 'ManuscriptDisplay': {
+      const filename = stringAttr(attrs, 'filename') ?? '';
+      return `\n\n[Manuscript: ${filename}]\n\n`;
+    }
+
+    // Quotation.
+    case 'PullQuote': {
+      const attribution = stringAttr(attrs, 'attribution');
+      const quoted = body
+        .trim()
+        .split('\n')
+        .map((line) => `> ${line}`)
+        .join('\n');
+      return `\n\n${quoted}${attribution ? `\n> — ${attribution}` : ''}\n\n`;
+    }
+
+    case 'Quote': {
+      const source = stringAttr(attrs, 'source');
+      const quoted = body
+        .trim()
+        .split('\n')
+        .map((line) => `> ${line}`)
+        .join('\n');
+      return `\n\n${quoted}${source ? `\n> — ${source}` : ''}\n\n`;
+    }
+
+    case 'Callout': {
+      const title = stringAttr(attrs, 'title');
+      const head = title ? `**${title}**\n\n` : '';
+      return `\n\n${head}${body}\n\n`;
+    }
+
+    // Data rows.
+    case 'Correspondence': {
+      const n = stringAttr(attrs, 'n') ?? '';
+      const glass = stringAttr(attrs, 'glass') ?? '';
+      const ring = stringAttr(attrs, 'ring') ?? '';
+      return `\n${n}. ${glass} ↔ ${ring}\n`;
+    }
+
+    case 'DefinitionItem': {
+      const term = stringAttr(attrs, 'term') ?? '';
+      const definition = stringAttr(attrs, 'definition') ?? '';
+      const source = stringAttr(attrs, 'source');
+      const head = `**${term}** — "${definition}"${source ? ` ${source}` : ''}`;
+      return `\n\n${head}\n\n${body}\n\n`;
+    }
+
+    // Inline.
+    case 'Ref': {
+      const n = stringAttr(attrs, 'n') ?? '';
+      const sub = stringAttr(attrs, 'sub') ?? '';
+      const kind = stringAttr(attrs, 'kind');
+      const num = kind === 'roman' ? toRoman(n) : n;
+      return `[^${num}${sub}]`;
+    }
+
+    case 'MarginNote':
+      return ` (margin: ${body.trim()}) `;
+
+    case 'AsideInline':
+      return ` (aside: ${body.trim()}) `;
+
+    case 'TitleCard': {
+      const id = stringAttr(attrs, 'id') ?? '';
+      return `[title card: ${id}]`;
+    }
+
+    // Fallback: unknown tags — unwrap if paired, drop if self-closing.
+    default:
+      return body;
+  }
+}
+
+/** Narrows an attribute to a plain string, returning undefined otherwise. */
+function stringAttr(attrs: Attrs, name: string): string | undefined {
+  const value = attrs[name];
+  if (typeof value === 'string') return value;
+  return undefined;
+}


### PR DESCRIPTION
## What
Promotes the LLM-accessibility funnel from dev to main. Rolls up four commits from PR #21 plus the merge commit (\`af97b4d\`).

## Why
Browser-tab LLMs (claude.ai, chat.com) and local-harnessed LLMs (Claude Code, Codex, OpenClaw) needed working paths into the site. The previous homepage note pointed at \`/llms.txt\` in a muted footnote, but nothing on the site linked to the JSON endpoints described there — browser LLMs hit a dead end. This change opens two doors prominently on the homepage, ships a Claude Code-style installable skill, builds a real HTML index page (\`/contents\`) for browser agents, rewrites \`/llms.txt\` per the llmstxt.org spec, and cleans up the underlying API to emit clean plaintext rather than raw MDX with JSX inline.

## Changes
- **\`lib/mdx-to-plain.ts\`** — per-component MDX→plaintext transformer, the only stripper in the repo (confirmed during review). Powers both \`/llms-full.txt\` and the refactored \`/api/llms/article\`.
- **\`/skill\`** — Claude Code-style installable skill, hand-authored. Leads with the JSON API as the canonical surface, then reader profiles by interest (Elden Ring fans, Duchampians, pataphysicians, punchline-only). Attribution as \`~dashus-navnul\` only.
- **\`/contents\`** — real HTML index of every readable page for browser-LLMs. Each entry is a literal \`<a>\` with summary; interactive routes flagged inline with rust badge + warning. Filters its own self-link.
- **\`/llms-full.txt\`** — single text/plain corpus dump, JSX stripped.
- **\`/llms.txt\`** — full rewrite per llmstxt.org spec, dynamically built from \`buildSidebar()\` + \`allContentPagesSorted()\`.
- **Homepage** — bottom-of-page muted footnote replaced with a prominent two-column callout: door **i** for the human reader working with a local agent (CopyButton with paste-ready install prompt), door **ii** for the browser-tab LLM landing here directly (link to \`/contents\`).
- **\`content/pages/layout.yaml\`** — injects \`/contents\` into the Errata sidebar.

## Testing
\`npm run check\` green locally; PR #21 verified all-green on GitHub Actions and Vercel preview through three rounds of review feedback before merging to dev.