### PR TITLE
chore: Elide /contents from the Stair sidebar

### DIFF
--- a/content/pages/layout.yaml
+++ b/content/pages/layout.yaml
@@ -19,11 +19,7 @@ order:
   - cosmology
   - critiques
   - author
-  - contents
 links:
   gatherer:
     href: /gatherer
     label: Elden Ring Item Cards
-  contents:
-    href: /contents
-    label: Contents · Apparatus for Agents


### PR DESCRIPTION
## What
Removes the \`/contents\` entry from the Stair sidebar by dropping it from \`content/pages/layout.yaml\` (both the \`order\` list and the \`links\` map).

## Why
Caught after merging PR #21: \`/contents\` was injected into the Stair so humans browsing the site could discover the LLM-friendly index, but on reflection that surface is for browser-based LLMs, not humans. The route stays live and is still reachable from the homepage callout's "Browse the index →" button — which is the audience that actually wants it.

## Changes
- \`content/pages/layout.yaml\` — drop the \`contents\` entry from \`order\` and the \`contents\` link from \`links\`.

## Testing
- \`npm run check\` green locally.