### PR TITLE
chore: Promote elide-/contents-from-Stair from dev

### DIFF
--- a/content/pages/layout.yaml
+++ b/content/pages/layout.yaml
@@ -19,11 +19,7 @@ order:
   - cosmology
   - critiques
   - author
-  - contents
 links:
   gatherer:
     href: /gatherer
     label: Elden Ring Item Cards
-  contents:
-    href: /contents
-    label: Contents · Apparatus for Agents


### PR DESCRIPTION
## What
Promotes the chore commit \`932f0b6\` (PR #23) from dev to main: removes \`/contents\` from the Stair sidebar's \`layout.yaml\`.

## Why
\`/contents\` is for browser-based LLMs and is reachable from the homepage callout's "Browse the index →" button. Listing it in the human-facing Stair was an over-injection caught in review of PR #21.

## Changes
- \`content/pages/layout.yaml\` — drop \`contents\` from \`order\` and from the \`links\` map.

## Testing
PR #23 verified all-green on GitHub Actions and Vercel before merging to dev.