### PR TITLE
feat: Center home hero button row, add Copy Prompt, fix brand

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Base URL for sitemap, RSS, and OG images
-NEXT_PUBLIC_BASE_URL=https://eldenglass.com
+NEXT_PUBLIC_BASE_URL=https://eldenringisthelargeglass.com
 
 # Optional: Analytics
-# NEXT_PUBLIC_PLAUSIBLE_DOMAIN=eldenglass.com
+# NEXT_PUBLIC_PLAUSIBLE_DOMAIN=eldenringisthelargeglass.com

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -1,4 +1,4 @@
-import { BookOpen, Zap } from 'lucide-react';
+import { BookOpen, Bot, Zap } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
 
@@ -43,7 +43,7 @@ export default function HomePage() {
       {/* Running head + seeded crackline */}
       <div>
         <div className="mb-3 flex items-baseline justify-between gap-4">
-          <Eyebrow tone="gold">Eldenglass · TL;DR</Eyebrow>
+          <Eyebrow tone="gold">Home</Eyebrow>
           <Spec>the claim, literally</Spec>
         </div>
         <Crackline seed="home-top" tone="gold" />
@@ -97,17 +97,24 @@ export default function HomePage() {
             </Spec>
           </div>
 
-          <div className="mt-8 flex flex-wrap gap-3">
-            <Button asChild size="lg" className="gap-2">
-              <Link href="/tldr">
-                <Zap className="h-4 w-4" />
-                TL;DR
-              </Link>
-            </Button>
+          <div className="mt-8 flex flex-wrap justify-center gap-3">
+            <CopyButton
+              value={UNIVERSAL_AGENT_PROMPT}
+              label="Copy Prompt"
+              variant="default"
+              size="lg"
+              icon={<Bot className="h-4 w-4" />}
+            />
             <Button asChild variant="outline" size="lg" className="gap-2">
               <Link href="/living-thesis">
                 <BookOpen className="h-4 w-4" />
-                Read the Living Thesis
+                Living Thesis
+              </Link>
+            </Button>
+            <Button asChild variant="outline" size="lg" className="gap-2">
+              <Link href="/tldr">
+                <Zap className="h-4 w-4" />
+                TL;DR
               </Link>
             </Button>
           </div>

--- a/components/site/copy-button.tsx
+++ b/components/site/copy-button.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 import { Check, Copy } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
@@ -8,9 +8,18 @@ import { Button } from '@/components/ui/button';
 interface CopyButtonProps {
   value: string;
   label?: string;
+  variant?: 'default' | 'ghost' | 'outline';
+  size?: 'default' | 'sm' | 'lg' | 'icon';
+  icon?: ReactNode;
 }
 
-export function CopyButton({ value, label = 'Copy' }: CopyButtonProps) {
+export function CopyButton({
+  value,
+  label = 'Copy',
+  variant = 'ghost',
+  size = 'sm',
+  icon = <Copy className="h-4 w-4" />,
+}: CopyButtonProps) {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = async () => {
@@ -20,8 +29,8 @@ export function CopyButton({ value, label = 'Copy' }: CopyButtonProps) {
   };
 
   return (
-    <Button variant="ghost" size="sm" onClick={handleCopy} className="gap-2">
-      {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+    <Button variant={variant} size={size} onClick={handleCopy} className="gap-2">
+      {copied ? <Check className="h-4 w-4" /> : icon}
       {copied ? 'Copied' : label}
     </Button>
   );


### PR DESCRIPTION
## What
Restructures the hero button row on the home page, introduces a gold Copy Prompt button that shares clipboard behavior with the existing LLM-instructions accordion, and scrubs two stale brand artifacts (the misnamed "Eldenglass" eyebrow on home, and the wrong domain in `.env.example`).

## Why
The home page previously lead with two link buttons (TL;DR, Living Thesis) and buried the agent-onboarding copy prompt inside the collapsed accordion. Surfacing the prompt copy as a first-class action — with a robot icon — gives agent-assisted humans a one-click path to paste the routing prompt into their harness, matching how the page expects to be used. The eyebrow and `.env.example` both referred to "eldenglass / eldenglass.com," which was never the real domain (the site is `eldenringisthelargeglass.com`).

## Changes
- Center the home hero button row (`justify-center`)
- Add gold Copy Prompt button that copies the same `UNIVERSAL_AGENT_PROMPT` the accordion copies
- Reorder row to Copy Prompt → Living Thesis → TL;DR
- Shift TL;DR from the gold default to `outline` so only the agent entry button carries gold
- Shorten "Read the Living Thesis" → "Living Thesis"
- Expand `CopyButton` with optional `variant` / `size` / `icon` props; defaults preserved so other callers are unchanged
- Replace home eyebrow "Eldenglass · TL;DR" with "Home"
- Fix `.env.example` base URL and Plausible domain example to `eldenringisthelargeglass.com`

## Testing
- `npm run typecheck` — passes
- `npm run build` — passes
- Preview deployment: verify the three-button row renders centered, the gold Copy Prompt button copies the full routing prompt to the clipboard, and the home eyebrow reads "Home"