### PR TITLE
docs: Clarify layout.yaml model, tighten README, sync CLAUDE and AGENTS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,2 @@
 # Base URL for sitemap, RSS, and OG images
 NEXT_PUBLIC_BASE_URL=https://eldenringisthelargeglass.com
-
-# Optional: Analytics
-# NEXT_PUBLIC_PLAUSIBLE_DOMAIN=eldenringisthelargeglass.com

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ a-ball-of-twine.txt
 Grant Us Eyes.pdf
 *.tsbuildinfo
 .worktrees
+.vercel

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ All work happens on a branch. Changes flow through:
 4. Open a PR into `dev`
 5. Request review
 6. Merge to `dev`
-7. Validate the deployed `dev` build online when behavior changed
+7. Validate the deployed `dev` build online
 8. Open a second PR from `dev` to `main`
 9. Request review
 10. Merge only after review
@@ -34,6 +34,24 @@ Every meaningful change should go through review.
 
 Docs changes are not exempt. Routing, content, and operational docs all affect
 how the repo is run.
+
+#### Reviewer Assignment For Agents
+
+If the human driving the agent is not `rabsef-bicrym`, and the PR touches
+anything other than article text in `content/pages/**/*.mdx`, the agent must:
+
+- assign `rabsef-bicrym` as a reviewer on the PR
+  (`gh pr edit <num> --add-reviewer rabsef-bicrym`)
+- not merge the PR — wait for `rabsef-bicrym` to leave an approving review on
+  GitHub, then let them merge
+
+Pure MDX article-text changes under `content/pages/**` are the one exception,
+because the source of truth is the prose itself and preview-URL verification
+is the real review.
+
+If the human driving the agent is `rabsef-bicrym`, their explicit chat
+confirmation stands in for the on-PR review, and the agent may merge after
+they say so.
 
 ## Core Rule
 
@@ -103,19 +121,46 @@ The content tree is interpreted by:
 
 Each `content/pages/**/layout.yaml` can control navigation and folder behavior.
 
-Supported keys:
+Supported top-level keys:
 
-- `primary`: marks top-level entries that should appear in primary navigation
-- `order`: orders sibling pages and sections
-- `hidden`: hides filesystem entries from generated navigation
-- `links`: injects internal or external links that are not backed by an MDX file
+- `primary`: root-only — names to surface in primary navigation
+- `order`: explicit sibling order in this folder
+- `hidden`: filesystem entries (MDX pages or subfolders) to hide from nav
+- `links`: injected nav entries that are not backed by an MDX file
 
-Use `links` for bespoke routes that should appear inside the content-driven nav.
+Each entry under `links` takes the following sub-keys:
 
-Current examples:
+- `href` (required): in-site path (e.g., `/gatherer`) or a full URL
+  (e.g., `https://example.com/thing`)
+- `label` (optional): display text in the sidebar; defaults to the link key
+- `external` (optional, default `false`): when `true`, the link opens in a
+  new tab with `rel="noopener noreferrer"` and is excluded from active-path
+  detection
+- `hidden` (optional, default `false`): suppresses the link from generated
+  nav
 
-- `content/pages/xenotext-theory/layout.yaml` links to `/xenotext`
-- `content/pages/duchamp/layout.yaml` links to `/duchamp/duchamp-works`
+To position an injected link among its siblings, add its key to the same
+folder's `order:` list. The three nav-element types all express through
+this one schema:
+
+1. **MDX-backed pages** — filesystem-discovered; no `layout.yaml` entry
+   required. `primary` / `order` / `hidden` still apply by name.
+2. **Internal interactive TSX routes** — a bespoke page under
+   `app/(site)/**` enters the sidebar only when a `layout.yaml` references
+   it via a `links:` entry with an in-site `href` (and no `external`).
+3. **External links** — same `links:` shape with `external: true` and a
+   full URL `href`.
+
+Live examples in the repo:
+
+- Root: `content/pages/layout.yaml` → `links.gatherer` points at
+  `/gatherer` to bring the interactive Gatherer route into the sidebar.
+- `content/pages/xenotext-theory/layout.yaml` → `links.cipher` points at
+  `/xenotext`.
+- `content/pages/duchamp/layout.yaml` → `links.duchamp-works` points at
+  `/duchamp/duchamp-works`.
+- There are no external-link examples currently, but the schema supports
+  them.
 
 ### Routing Model
 
@@ -220,6 +265,17 @@ Agentation is a collaboration aid. The source of truth remains:
 - MDX in `content/pages/**`
 - structured data in `data/**`
 - rendering logic in components and route files
+
+### Setup
+
+Agentation is pre-installed in this repo. No setup is required — running
+`npm run dev` is enough. The toolbar mounts in development only, via
+`components/agentation-dev.tsx` and `app/layout.tsx`.
+
+The `endpoint` prop (`http://localhost:4747`) is optional. If an Agent Sync
+server is running locally on that port, Agentation will sync annotations to
+it. If not, the toolbar still works — annotate the page and copy the
+structured markdown output to the clipboard manually.
 
 ## Verification
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ All work happens on a branch. Changes flow through:
 4. Open a PR into `dev`
 5. Request review
 6. Merge to `dev`
-7. Validate the deployed `dev` build online when behavior changed
+7. Validate the deployed `dev` build online
 8. Open a second PR from `dev` to `main`
 9. Request review
 10. Merge only after review
@@ -34,6 +34,24 @@ Every meaningful change should go through review.
 
 Docs changes are not exempt. Routing, content, and operational docs all affect
 how the repo is run.
+
+#### Reviewer Assignment For Agents
+
+If the human driving the agent is not `rabsef-bicrym`, and the PR touches
+anything other than article text in `content/pages/**/*.mdx`, the agent must:
+
+- assign `rabsef-bicrym` as a reviewer on the PR
+  (`gh pr edit <num> --add-reviewer rabsef-bicrym`)
+- not merge the PR — wait for `rabsef-bicrym` to leave an approving review on
+  GitHub, then let them merge
+
+Pure MDX article-text changes under `content/pages/**` are the one exception,
+because the source of truth is the prose itself and preview-URL verification
+is the real review.
+
+If the human driving the agent is `rabsef-bicrym`, their explicit chat
+confirmation stands in for the on-PR review, and the agent may merge after
+they say so.
 
 ## Core Rule
 
@@ -103,19 +121,46 @@ The content tree is interpreted by:
 
 Each `content/pages/**/layout.yaml` can control navigation and folder behavior.
 
-Supported keys:
+Supported top-level keys:
 
-- `primary`: marks top-level entries that should appear in primary navigation
-- `order`: orders sibling pages and sections
-- `hidden`: hides filesystem entries from generated navigation
-- `links`: injects internal or external links that are not backed by an MDX file
+- `primary`: root-only — names to surface in primary navigation
+- `order`: explicit sibling order in this folder
+- `hidden`: filesystem entries (MDX pages or subfolders) to hide from nav
+- `links`: injected nav entries that are not backed by an MDX file
 
-Use `links` for bespoke routes that should appear inside the content-driven nav.
+Each entry under `links` takes the following sub-keys:
 
-Current examples:
+- `href` (required): in-site path (e.g., `/gatherer`) or a full URL
+  (e.g., `https://example.com/thing`)
+- `label` (optional): display text in the sidebar; defaults to the link key
+- `external` (optional, default `false`): when `true`, the link opens in a
+  new tab with `rel="noopener noreferrer"` and is excluded from active-path
+  detection
+- `hidden` (optional, default `false`): suppresses the link from generated
+  nav
 
-- `content/pages/xenotext-theory/layout.yaml` links to `/xenotext`
-- `content/pages/duchamp/layout.yaml` links to `/duchamp/duchamp-works`
+To position an injected link among its siblings, add its key to the same
+folder's `order:` list. The three nav-element types all express through
+this one schema:
+
+1. **MDX-backed pages** — filesystem-discovered; no `layout.yaml` entry
+   required. `primary` / `order` / `hidden` still apply by name.
+2. **Internal interactive TSX routes** — a bespoke page under
+   `app/(site)/**` enters the sidebar only when a `layout.yaml` references
+   it via a `links:` entry with an in-site `href` (and no `external`).
+3. **External links** — same `links:` shape with `external: true` and a
+   full URL `href`.
+
+Live examples in the repo:
+
+- Root: `content/pages/layout.yaml` → `links.gatherer` points at
+  `/gatherer` to bring the interactive Gatherer route into the sidebar.
+- `content/pages/xenotext-theory/layout.yaml` → `links.cipher` points at
+  `/xenotext`.
+- `content/pages/duchamp/layout.yaml` → `links.duchamp-works` points at
+  `/duchamp/duchamp-works`.
+- There are no external-link examples currently, but the schema supports
+  them.
 
 ### Routing Model
 
@@ -220,6 +265,17 @@ Agentation is a collaboration aid. The source of truth remains:
 - MDX in `content/pages/**`
 - structured data in `data/**`
 - rendering logic in components and route files
+
+### Setup
+
+Agentation is pre-installed in this repo. No setup is required — running
+`npm run dev` is enough. The toolbar mounts in development only, via
+`components/agentation-dev.tsx` and `app/layout.tsx`.
+
+The `endpoint` prop (`http://localhost:4747`) is optional. If an Agent Sync
+server is running locally on that port, Agentation will sync annotations to
+it. If not, the toolbar still works — annotate the page and copy the
+structured markdown output to the clipboard manually.
 
 ## Verification
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ Agentation is installed for dev-time visual collaboration with AI agents.
 - it is only rendered in development via `app/layout.tsx`
 - use it to annotate exact content/UI on the running site when working with an LLM
 
+No setup is required beyond `npm run dev`. The toolbar mounts automatically
+in development. The `endpoint` prop (`http://localhost:4747`) is optional:
+if an Agent Sync server is running locally on that port, Agentation will
+sync annotations to it; if not, the toolbar still works — annotate the page
+and copy the structured markdown output to the clipboard manually.
+
 Preferred content workflow:
 
 1. run the site locally
@@ -89,6 +95,9 @@ Do not commit directly to `main`.
 
 Do not push directly to `main`.
 
+See `CLAUDE.md` / `AGENTS.md` for the authoritative version of this flow,
+including reviewer-assignment rules for agent-driven PRs.
+
 One environment variable is set in Vercel:
 
 - `NEXT_PUBLIC_BASE_URL` = `https://eldenringisthelargeglass.com`
@@ -100,24 +109,67 @@ The site verifies two independent attestations of the original discovery:
 1. **Initial Thesis** -- SHA-256 hash of `manuscript.txt` attested on Ethereum via EAS (Ethereum Attestation Service). The hash and attestation UID are in the MDX frontmatter.
 2. **TL;DR** -- SHA-256 hash of `EldenRingSecretOriginal.md` timestamped on Bitcoin via OpenTimestamps. The `.ots` proof file is in `public/proofs/`.
 
-Both proof files are served from `public/proofs/` so readers can independently verify.
+The OpenTimestamps `.ots` proof and both source documents (`manuscript.txt`
+and `EldenRingSecretOriginal.md`) are served from `public/proofs/` so
+readers can independently recompute the hashes and verify the attestations.
 
-## Project Structure
+## How this repo is laid out
 
-```
-app/                    Routes and API endpoints
-  (site)/               All content pages (living-thesis, vocab, gatherer, etc.)
-  api/                  Title card, search, and sense-index endpoints
-components/
-  mdx/                  MDX components (MarkdownRenderer, DefinitionItem, FloatImage, etc.)
-  site/                 Layout (sidebar, top bar, navigation)
-  title-cards/          Rollover display, detail modal, provider
-  verification/         Hash verification UI
-content/                MDX source files
-data/                   Title cards JSON, sense index, xenotext theories
-lib/                    Content getters, search index, utilities
-public/
-  proofs/               Attestation proof files
-  images/               All site imagery (Duchamp works, ER characters, etc.)
-  animations/           Large Glass component GIFs
-```
+This site is filesystem + YAML driven by design. Pages, section ordering,
+injected TSX routes, and external sidebar links all flow through the
+`content/pages/**` filesystem tree and the `layout.yaml` files inside it. The
+authoritative description lives in `CLAUDE.md` / `AGENTS.md`. A brief
+orientation:
+
+- **Content is filesystem-shaped.** MDX files under `content/pages/**` and
+  each folder's `layout.yaml` determine which pages exist, their order, and
+  how they appear in navigation. Adding a page is adding an MDX file;
+  reorganising a section is moving files and tweaking that folder's
+  `layout.yaml`.
+
+- **`layout.yaml` has four keys:** `primary` (root-only, surfaces names in
+  primary nav), `order` (explicit sibling order), `hidden` (hides filesystem
+  entries from nav), and `links` (injects nav entries not backed by an MDX
+  file). Each `links` entry takes `href`, `label`, and optional
+  `external: true` (opens in a new tab with `rel="noopener noreferrer"`) and
+  `hidden: true`. Place the link key in `order:` to position it among its
+  siblings. Live examples:
+  - `links.gatherer → /gatherer` in `content/pages/layout.yaml` injects the
+    bespoke `/gatherer` TSX route at the root of the sidebar.
+  - `links.cipher → /xenotext` in
+    `content/pages/xenotext-theory/layout.yaml` injects the `/xenotext` TSX
+    route into the Xenotext Theory section.
+  - `links.duchamp-works → /duchamp/duchamp-works` in
+    `content/pages/duchamp/layout.yaml` does the same for the
+    `/duchamp/duchamp-works` TSX route.
+  - External sites use the same shape with `href: https://...` and
+    `external: true`.
+
+- **Routes live in `app/`.** `app/(site)/[...slug]/page.tsx` is the
+  content-driven catch-all that serves MDX pages from `content/pages/**`.
+  Bespoke (non-content) interactive routes live as their own folders under
+  `app/(site)/`; they appear in navigation only when a `layout.yaml`
+  references them via a `links:` entry. `app/api/**` contains JSON endpoints
+  (search, title cards, sense index, and agent-facing `llms` routes).
+
+- **Structured data lives in `data/`** — title cards, sense index,
+  manuscripts manifest, Duchamp artworks catalog, xenotext theories. See
+  `data/README.md`.
+
+- **Generation machinery lives in `lib/` and `contentlayer.config.ts`.**
+  Key files: `lib/content.ts`, `lib/content-tree.ts`, `lib/sidebar.ts`,
+  `contentlayer.config.ts`. Don't duplicate navigation or page-discovery
+  logic elsewhere.
+
+- **Components, scripts, and public assets grow organically.** Check the
+  filesystem for what's there rather than a list here. Entry points worth
+  knowing: `components/mdx/markdown-renderer.tsx` (MDX renderer + component
+  registry), `components/site/` (site shell), `components/delay/`
+  (thesis-voice primitives used across content pages and the home hero),
+  `scripts/` (sync scripts for critique assets, manuscripts, and FedWiki
+  import/export).
+
+- **Proofs and attestations.** `public/proofs/` holds the Bitcoin
+  OpenTimestamps `.ots` proof for the TL;DR plus the two source documents
+  (`manuscript.txt`, `EldenRingSecretOriginal.md`) whose SHA-256 hashes are
+  the subject of the EAS and OpenTimestamps attestations.


### PR DESCRIPTION
## What
Clarifies how the site actually generates its navigation from the `content/pages/**` filesystem plus `layout.yaml` files, and removes drift-prone indicia from the docs. Replaces the static README directory tree with a prose description of the generative model, enumerates the full `layout.yaml` schema (including the `links:` sub-keys and the three navigation-element types it expresses), and cleans up a handful of stale or speculative lines across `README.md`, `CLAUDE.md`, `AGENTS.md`, and `.env.example`.

## Why
The previous README `## Project Structure` block listed directories and example pages as if the structure were fixed. In practice the site is filesystem + YAML driven by design — adding a page is adding an MDX file; wiring a bespoke interactive route into the sidebar is a `links:` entry in the relevant `layout.yaml`; the whole point is that the tree moves. A static tree both lied about that and drifted out of date (e.g., `vocab` wasn't a route, `llms` and `related-by-sense` APIs were missing, `components/delay/` and `scripts/` weren't mentioned). `CLAUDE.md` and `AGENTS.md` named the right keys but never showed the `href`/`label`/`external`/`hidden` sub-keys on `links:` or the fact that `order:` is how you place an injected link. `.env.example` had a commented `NEXT_PUBLIC_PLAUSIBLE_DOMAIN` line that pointed at nothing — Plausible is not integrated anywhere in the codebase, and `vercel env ls` confirms the only env var set in Vercel is `NEXT_PUBLIC_BASE_URL`.

## Changes
- Rewrite `## Project Structure` → `## How this repo is laid out` in the README as prose describing the generative model
- Enumerate the `layout.yaml` schema (top-level keys + `links:` sub-keys) and the three nav-element types (MDX page, injected internal TSX route, injected external link) in both README and CLAUDE.md/AGENTS.md, with live repo examples
- Add `Reviewer Assignment For Agents` under `Request Review` in CLAUDE.md/AGENTS.md
- Add Agentation `Setup` subsection clarifying no setup is required beyond `npm run dev` and the `:4747` endpoint is optional
- Drop the `when behavior changed` conditional from step 7 of the PR flow in both CLAUDE.md/AGENTS.md and README.md; dev preview validation is unconditional
- Remove the orphan Plausible env var line from `.env.example`
- Fix the Blockchain Attestations closing sentence: one OpenTimestamps `.ots` proof plus two source documents, not "both proof files"
- Add `.vercel` to `.gitignore` so `vercel link` state never lands in commits

## Testing
- Docs-only change; no code paths affected
- Previously documented live examples re-verified against the repo: `content/pages/layout.yaml` → `/gatherer`, `content/pages/xenotext-theory/layout.yaml` → `/xenotext`, `content/pages/duchamp/layout.yaml` → `/duchamp/duchamp-works`
- Vercel env state confirmed via `vercel env ls` (only `NEXT_PUBLIC_BASE_URL` on Production)