### PR TITLE
fix: Allow LLM API routes in robots

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -6,7 +6,7 @@ export default function robots(): MetadataRoute.Robots {
   return {
     rules: {
       userAgent: '*',
-      allow: '/',
+      allow: ['/', '/api/llms/'],
       disallow: ['/api/', '/admin/'],
     },
     sitemap: `${BASE_URL}/sitemap.xml`,


### PR DESCRIPTION
## What
Allows robot-aware clients to fetch the LLM API endpoints while keeping the rest of `/api/` blocked from crawling.

## Why
Browser harnesses that honor `robots.txt` were refusing `https://eldenringisthelargeglass.com/api/llms/toc` because the site disallowed all `/api/` paths. The LLM TOC and article endpoints are intentionally agent-facing, so they need an explicit allow rule.

## Changes
- Allow `/api/llms/` in `robots.txt`
- Preserve broader `/api/` and `/admin/` disallows

## Testing
- `npm run check`
- `curl -s http://localhost:3000/robots.txt`
