### PR TITLE
fix: Promote LLM robots allowance to main

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -6,7 +6,7 @@ export default function robots(): MetadataRoute.Robots {
   return {
     rules: {
       userAgent: '*',
-      allow: '/',
+      allow: ['/', '/api/llms/'],
       disallow: ['/api/', '/admin/'],
     },
     sitemap: `${BASE_URL}/sitemap.xml`,


### PR DESCRIPTION
## What
Promotes the robots.txt fix from `dev` to `main`.

## Why
Robot-aware browser harnesses were refusing `/api/llms/toc` because the site disallowed all `/api/` paths. The LLM API endpoints are intentionally public agent-facing routes, so `/api/llms/` needs an explicit allow rule.

## Changes
- Allow `/api/llms/` in robots.txt
- Keep broader `/api/` blocked
- Keep `/admin/` blocked

## Testing
- `npm run check`
- `curl -s http://localhost:3000/robots.txt`
- Vercel preview confirmed
