### PR TITLE
fix: Smooth mobile search result navigation

### DIFF
--- a/components/delay/seal-strip.tsx
+++ b/components/delay/seal-strip.tsx
@@ -83,7 +83,18 @@ export function SealStrip({ navigation, stairSeal }: SealStripProps) {
           <SheetContent className="w-[min(26rem,calc(100vw-1rem))] max-w-[calc(100vw-1rem)] p-0">
             <SheetTitle className="sr-only">Elden Glass Navigation</SheetTitle>
             <div onClick={(event) => handleSheetNav(event, () => setOpen(false))}>
-              <StairNav navigation={navigation} seal={stairSeal} />
+              <StairNav
+                navigation={navigation}
+                seal={stairSeal}
+                onSearchNavigate={(navigate) => {
+                  setOpen(false);
+                  window.setTimeout(navigate, 180);
+                }}
+                onSearchResultNavigate={(navigate) => {
+                  setOpen(false);
+                  window.setTimeout(navigate, 180);
+                }}
+              />
             </div>
           </SheetContent>
         </Sheet>

--- a/components/delay/stair.tsx
+++ b/components/delay/stair.tsx
@@ -34,13 +34,22 @@ type StairNavProps = {
   navigation: SiteNavigation;
   /** Optional bottom-of-stair seal — e.g. "LIVING · THESIS / Updated Apr 21". */
   seal?: StairSealCopy;
+  /** Lets mobile chrome close before the search page navigation runs. */
+  onSearchNavigate?: (navigate: () => void) => void;
+  /** Lets mobile chrome close before a selected search result navigates. */
+  onSearchResultNavigate?: (navigate: () => void) => void;
 };
 
 // Single marker for every rung and section header. Changing the glyph
 // in one place ripples through the whole stair.
 const RUNG_MARKER = '§';
 
-export function StairNav({ navigation, seal }: StairNavProps) {
+export function StairNav({
+  navigation,
+  seal,
+  onSearchNavigate,
+  onSearchResultNavigate,
+}: StairNavProps) {
   const pathname = usePathname() ?? '/';
 
   return (
@@ -74,7 +83,11 @@ export function StairNav({ navigation, seal }: StairNavProps) {
       </div>
 
       <div style={{ margin: '0 0 24px', paddingRight: 8 }}>
-        <GlobalSearch variant="sidebar" />
+        <GlobalSearch
+          variant="sidebar"
+          onSearchNavigate={onSearchNavigate}
+          onResultNavigate={onSearchResultNavigate}
+        />
       </div>
 
       {navigation.primary.map((item) => (

--- a/components/mdx/search-block-client.tsx
+++ b/components/mdx/search-block-client.tsx
@@ -1,25 +1,40 @@
 'use client';
 
 import { useEffect } from 'react';
+import { usePathname } from 'next/navigation';
+import {
+  SEARCH_TARGET_EVENT,
+  clearPendingSearchTarget,
+  getPendingSearchTarget,
+} from '@/lib/search-navigation';
 
 /**
  * Flashes a search-target block when the URL hash points at one.
  */
 export function SearchTargetFlash() {
+  const pathname = usePathname() ?? '/';
+
   useEffect(() => {
     let timeoutId: number | undefined;
+    let observer: MutationObserver | undefined;
 
-    const flashTarget = () => {
-      const hash = window.location.hash;
-      const targetId = hash.startsWith('#') ? decodeURIComponent(hash.slice(1)) : '';
-
+    const flashTarget = (targetId: string, shouldScroll = false) => {
       if (!targetId) {
-        return;
+        return false;
       }
 
       const target = document.getElementById(targetId);
       if (!target || target.dataset.searchBlock !== 'true') {
-        return;
+        return false;
+      }
+
+      if (shouldScroll) {
+        target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        window.history.replaceState(
+          window.history.state,
+          '',
+          `${window.location.pathname}${window.location.search}#${encodeURIComponent(targetId)}`
+        );
       }
 
       target.classList.remove('search-target-flash');
@@ -30,17 +45,60 @@ export function SearchTargetFlash() {
       timeoutId = window.setTimeout(() => {
         target.classList.remove('search-target-flash');
       }, 4000);
+
+      return true;
     };
 
-    const frameId = window.requestAnimationFrame(flashTarget);
-    window.addEventListener('hashchange', flashTarget);
+    const scrollToTargetWhenReady = (targetId: string) => {
+      if (flashTarget(targetId, true)) {
+        clearPendingSearchTarget();
+        return;
+      }
+
+      observer = new MutationObserver(() => {
+        if (flashTarget(targetId, true)) {
+          clearPendingSearchTarget();
+          observer?.disconnect();
+          observer = undefined;
+        }
+      });
+      observer.observe(document.body, { childList: true, subtree: true });
+    };
+
+    const flashHashTarget = () => {
+      const hash = window.location.hash;
+      const targetId = hash.startsWith('#') ? decodeURIComponent(hash.slice(1)) : '';
+      flashTarget(targetId);
+    };
+
+    const flashRequestedTarget = (event: Event) => {
+      const targetId = (event as CustomEvent<{ targetId?: string }>).detail?.targetId;
+      if (targetId) {
+        scrollToTargetWhenReady(targetId);
+      }
+    };
+
+    const pendingTarget = getPendingSearchTarget(pathname);
+    const frameId = window.requestAnimationFrame(() => {
+      if (pendingTarget) {
+        scrollToTargetWhenReady(pendingTarget.targetId);
+        return;
+      }
+
+      flashHashTarget();
+    });
+
+    window.addEventListener('hashchange', flashHashTarget);
+    window.addEventListener(SEARCH_TARGET_EVENT, flashRequestedTarget);
 
     return () => {
       window.cancelAnimationFrame(frameId);
-      window.removeEventListener('hashchange', flashTarget);
+      observer?.disconnect();
+      window.removeEventListener('hashchange', flashHashTarget);
+      window.removeEventListener(SEARCH_TARGET_EVENT, flashRequestedTarget);
       window.clearTimeout(timeoutId);
     };
-  }, []);
+  }, [pathname]);
 
   return null;
 }

--- a/components/site/global-search.tsx
+++ b/components/site/global-search.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { Search, X, BookText } from 'lucide-react';
+import { dispatchSearchTarget, savePendingSearchTarget } from '@/lib/search-navigation';
 
 interface SearchResult {
   id: string;
@@ -15,11 +16,21 @@ interface SearchResult {
   cardId?: string;
 }
 
+const SEARCH_PREVIEW_LIMIT = 8;
+const SEARCH_PREVIEW_CANDIDATE_LIMIT = 64;
+const SEARCH_PREVIEW_MAX_RESULTS_PER_PAGE = 2;
+
 interface GlobalSearchProps {
   variant?: 'sidebar' | 'topbar';
+  onSearchNavigate?: (navigate: () => void) => void;
+  onResultNavigate?: (navigate: () => void) => void;
 }
 
-export function GlobalSearch({ variant = 'topbar' }: GlobalSearchProps) {
+export function GlobalSearch({
+  variant = 'topbar',
+  onSearchNavigate,
+  onResultNavigate,
+}: GlobalSearchProps) {
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<SearchResult[]>([]);
   const [isOpen, setIsOpen] = useState(false);
@@ -28,10 +39,11 @@ export function GlobalSearch({ variant = 'topbar' }: GlobalSearchProps) {
   const router = useRouter();
   const searchRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const shouldShowPreview = variant !== 'sidebar' || Boolean(onResultNavigate);
 
   // Debounced search
   useEffect(() => {
-    if (query.length < 2) {
+    if (!shouldShowPreview || query.length < 2) {
       setResults([]);
       setIsOpen(false);
       return;
@@ -40,10 +52,11 @@ export function GlobalSearch({ variant = 'topbar' }: GlobalSearchProps) {
     setIsLoading(true);
     const timer = setTimeout(async () => {
       try {
-        // Get top 8 results for dropdown preview
-        const response = await fetch(`/api/search?q=${encodeURIComponent(query)}&limit=8`);
+        const response = await fetch(
+          `/api/search?q=${encodeURIComponent(query)}&limit=${SEARCH_PREVIEW_CANDIDATE_LIMIT}`
+        );
         const data = await response.json();
-        setResults(data.results || []);
+        setResults(buildPreviewResults(data.results || []));
         setIsOpen(true); // Always show dropdown when searching
         setSelectedIndex(0);
       } catch (error) {
@@ -54,7 +67,7 @@ export function GlobalSearch({ variant = 'topbar' }: GlobalSearchProps) {
     }, 300);
 
     return () => clearTimeout(timer);
-  }, [query]);
+  }, [query, shouldShowPreview]);
 
   // Click outside to close
   useEffect(() => {
@@ -70,13 +83,23 @@ export function GlobalSearch({ variant = 'topbar' }: GlobalSearchProps) {
 
   // Go to search page
   const goToSearchPage = () => {
+    const destination = query.trim() ? `/search?q=${encodeURIComponent(query.trim())}` : '/search';
+
+    const navigate = () => router.push(destination as any);
+
     if (query.trim()) {
       setIsOpen(false);
       setQuery('');
-      router.push(`/search?q=${encodeURIComponent(query.trim())}`);
     } else {
-      router.push('/search');
+      setIsOpen(false);
     }
+
+    if (onSearchNavigate) {
+      onSearchNavigate(navigate);
+      return;
+    }
+
+    navigate();
   };
 
   // Keyboard navigation
@@ -105,15 +128,34 @@ export function GlobalSearch({ variant = 'topbar' }: GlobalSearchProps) {
     setIsOpen(false);
     setQuery('');
 
-    if (result.type === 'titlecard' && result.cardId) {
-      router.push(
-        `/gatherer?card=${encodeURIComponent(result.cardId)}&q=${encodeURIComponent(result.sentence)}`
-      );
+    const navigate = () => {
+      if (result.type === 'titlecard' && result.cardId) {
+        router.push(
+          `/gatherer?card=${encodeURIComponent(result.cardId)}&q=${encodeURIComponent(result.sentence)}`
+        );
+        return;
+      }
+
+      if (result.targetId) {
+        if (window.location.pathname === result.page) {
+          dispatchSearchTarget(result.targetId);
+          return;
+        }
+
+        savePendingSearchTarget({ page: result.page, targetId: result.targetId });
+        router.push(result.page as any, { scroll: false });
+        return;
+      }
+
+      router.push(result.page as any);
+    };
+
+    if (onResultNavigate) {
+      onResultNavigate(navigate);
       return;
     }
 
-    const destination = result.targetId ? `${result.page}#${result.targetId}` : result.page;
-    router.push(destination as any);
+    navigate();
   };
 
   const handleClear = () => {
@@ -140,7 +182,9 @@ export function GlobalSearch({ variant = 'topbar' }: GlobalSearchProps) {
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           onKeyDown={handleKeyDown}
-          onFocus={() => query.length >= 2 && results.length > 0 && setIsOpen(true)}
+          onFocus={() =>
+            shouldShowPreview && query.length >= 2 && results.length > 0 && setIsOpen(true)
+          }
           placeholder="Search the site..."
           className="w-full pl-10 pr-10 py-2 bg-[rgb(var(--bg-secondary-rgb)/0.5)] border border-[var(--border-subtle)] rounded-lg text-sm text-[var(--text-primary)] placeholder:text-[var(--text-tertiary)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-gold)] focus:border-transparent transition-all"
         />
@@ -155,11 +199,11 @@ export function GlobalSearch({ variant = 'topbar' }: GlobalSearchProps) {
       </div>
 
       {/* Dropdown Results */}
-      {isOpen && (
+      {shouldShowPreview && isOpen && (
         <div
           className={
             variant === 'sidebar'
-              ? 'absolute left-0 right-0 top-full mt-2 max-h-[60vh] overflow-y-auto border border-[var(--pane-edge)] bg-[var(--ink-2)] shadow-2xl z-[100] lg:fixed lg:left-[300px] lg:right-auto lg:top-[120px] lg:mt-0 lg:w-[min(500px,calc(100vw-320px))] lg:max-h-[70vh]'
+              ? 'absolute left-0 right-0 top-full mt-2 max-h-[60vh] overflow-y-auto border border-[var(--pane-edge)] bg-[var(--ink-2)] shadow-2xl z-[100]'
               : 'absolute top-full mt-2 w-full bg-[var(--bg-secondary)] border border-[var(--border-emphasis)] rounded-lg shadow-2xl overflow-hidden z-50 max-h-[70vh] overflow-y-auto'
           }
         >
@@ -231,6 +275,27 @@ export function GlobalSearch({ variant = 'topbar' }: GlobalSearchProps) {
       )}
     </div>
   );
+}
+
+function buildPreviewResults(results: SearchResult[]): SearchResult[] {
+  const pageCounts = new Map<string, number>();
+  const preview: SearchResult[] = [];
+
+  for (const result of results) {
+    const count = pageCounts.get(result.page) ?? 0;
+    if (count >= SEARCH_PREVIEW_MAX_RESULTS_PER_PAGE) {
+      continue;
+    }
+
+    pageCounts.set(result.page, count + 1);
+    preview.push(result);
+
+    if (preview.length >= SEARCH_PREVIEW_LIMIT) {
+      return preview;
+    }
+  }
+
+  return preview;
 }
 
 // Helper function to highlight matching text

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -17,7 +17,10 @@ const SheetOverlay = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Overlay
-    className={cn('fixed inset-0 z-[90] bg-[rgba(0,0,0,0.78)] backdrop-blur-sm', className)}
+    className={cn(
+      'fixed inset-0 z-[90] bg-[rgba(0,0,0,0.78)] backdrop-blur-sm data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      className
+    )}
     {...props}
     ref={ref}
   />
@@ -33,7 +36,7 @@ const SheetContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-0 top-0 z-[100] flex h-[100dvh] max-h-[100dvh] w-80 max-w-[85vw] flex-col overflow-hidden border-r border-[var(--border-subtle)] bg-[var(--bg-secondary)] shadow-panel outline-none',
+        'fixed left-0 top-0 z-[100] flex h-[100dvh] max-h-[100dvh] w-80 max-w-[85vw] flex-col overflow-hidden border-r border-[var(--border-subtle)] bg-[var(--bg-secondary)] shadow-panel outline-none data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left',
         className
       )}
       {...props}

--- a/lib/search-index.ts
+++ b/lib/search-index.ts
@@ -14,6 +14,7 @@ export interface SearchDocument {
   title: string;
   pageTitle: string;
   summary: string;
+  context: string;
   body: string;
   headings: string;
   section: string;
@@ -63,6 +64,7 @@ const STORE_FIELDS = [
   'title',
   'pageTitle',
   'summary',
+  'context',
   'body',
   'section',
   'category',
@@ -209,6 +211,7 @@ function contentPageToSearchDocuments(page: ContentPage): SearchDocument[] {
     title: page.title,
     pageTitle: page.title,
     summary: page.summary,
+    context: page.summary,
     headings: page.headings.map((heading) => heading.text).join(' '),
     section: '',
     category: '',
@@ -228,6 +231,7 @@ function contentPageToSearchDocuments(page: ContentPage): SearchDocument[] {
     ...extractSearchableBlocks(page.body.raw).map((block, index) => ({
       ...base,
       id: `content:${page.slug}:${index}:${block.id}`,
+      summary: '',
       body: block.text,
       targetId: block.id,
     })),
@@ -240,6 +244,7 @@ function critiqueToSearchDocuments(critique: Critique): SearchDocument[] {
     title: critique.title,
     pageTitle: critique.title,
     summary: critique.summary,
+    context: critique.summary,
     headings: '',
     section: 'Critiques',
     category: critique.targetTitle,
@@ -259,6 +264,7 @@ function critiqueToSearchDocuments(critique: Critique): SearchDocument[] {
     ...extractSearchableBlocks(critique.body.raw).map((block, index) => ({
       ...base,
       id: `critique:${critique.slug}:${index}:${block.id}`,
+      summary: '',
       body: block.text,
       targetId: block.id,
     })),
@@ -277,6 +283,7 @@ function getCustomPageSearchDocuments(): SearchDocument[] {
       title: entry.title,
       pageTitle: entry.title,
       summary: entry.summary,
+      context: entry.summary,
       body: entry.summary,
       headings: '',
       section: entry.kind,
@@ -298,6 +305,7 @@ function titleCardToSearchDocument(card: TitleCard): SearchDocument {
     title: publicCard.title,
     pageTitle: publicCard.section || 'Item Cards',
     summary: publicCard.description ?? '',
+    context: publicCard.description ?? '',
     body: publicCard.description ?? '',
     headings: '',
     section: publicCard.section ?? '',
@@ -317,7 +325,7 @@ function toSearchResult(document: SearchDocument): SearchResult {
       document.kind === 'custom-page'
         ? document.title
         : snippetFromText(document.body || document.title),
-    context: snippetFromText(document.summary || document.body),
+    context: snippetFromText(document.context || document.summary || document.body),
     page: document.url,
     pageTitle: document.pageTitle,
     targetId: document.targetId,

--- a/lib/search-navigation.ts
+++ b/lib/search-navigation.ts
@@ -1,0 +1,50 @@
+const PENDING_SEARCH_TARGET_KEY = 'elden-glass:pending-search-target';
+export const SEARCH_TARGET_EVENT = 'elden-glass:search-target';
+
+export type PendingSearchTarget = {
+  page: string;
+  targetId: string;
+};
+
+/**
+ * Stores a search-result block target so the destination page can scroll to it smoothly.
+ */
+export function savePendingSearchTarget(target: PendingSearchTarget) {
+  window.sessionStorage.setItem(PENDING_SEARCH_TARGET_KEY, JSON.stringify(target));
+}
+
+/**
+ * Requests a smooth scroll to a search target on the already-mounted page.
+ */
+export function dispatchSearchTarget(targetId: string) {
+  window.dispatchEvent(new CustomEvent(SEARCH_TARGET_EVENT, { detail: { targetId } }));
+}
+
+/**
+ * Reads a pending search target when the current page owns it.
+ */
+export function getPendingSearchTarget(page: string): PendingSearchTarget | null {
+  const rawTarget = window.sessionStorage.getItem(PENDING_SEARCH_TARGET_KEY);
+  if (!rawTarget) {
+    return null;
+  }
+
+  try {
+    const target = JSON.parse(rawTarget) as PendingSearchTarget;
+    if (target.page !== page) {
+      return null;
+    }
+
+    return target;
+  } catch {
+    window.sessionStorage.removeItem(PENDING_SEARCH_TARGET_KEY);
+    return null;
+  }
+}
+
+/**
+ * Clears a pending search target after it has been consumed.
+ */
+export function clearPendingSearchTarget() {
+  window.sessionStorage.removeItem(PENDING_SEARCH_TARGET_KEY);
+}


### PR DESCRIPTION
## What

Fixes the mobile search preview flow so selecting a suggestion closes the navigation sheet, routes directly to the selected page, and smoothly scrolls to the matched block once it exists. Desktop sidebar search no longer renders preview suggestions; it submits to the search page instead.

## Why

The mobile search preview was visually useful but the selection aftermath felt broken: the route changed behind the open menu, hash navigation could snap instead of animate, and the preview itself could look arbitrary because block records were matching inherited page summaries. On desktop, the same preview fought with the full search page and should not appear.

## Changes

- Close mobile sheet before navigation
- Smooth-scroll to selected blocks
- Wait for target block DOM
- Animate sheet open and close
- Diversify suggestion preview results
- Stop block-summary false matches
- Disable desktop sidebar previews

## Testing

- `npm run check`
- Manual local testing on `localhost:4000` for mobile menu search, suggestion click, Enter-to-search, desktop sidebar search, and block-target scrolling
