### PR TITLE
feat: add Martian author-page credit

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -102,6 +102,13 @@
   --success-green: var(--verdigris);
   --accent-red: var(--rust);
 
+  /* Martian credit mark — site-specific retint controls */
+  --martian-disc-bright: var(--border-emphasis);
+  --martian-disc-dark: var(--ink-3);
+  --martian-dot: var(--gold-bright);
+  --martian-dot-trail: var(--gold-bright);
+  --martian-moon: var(--paper-dim);
+
   /* RGB tuples for rgba() consumers */
   --bg-primary-rgb: 10 9 8;
   --bg-secondary-rgb: 19 17 15;

--- a/components/mdx/markdown-renderer.tsx
+++ b/components/mdx/markdown-renderer.tsx
@@ -36,6 +36,7 @@ import { GoldText } from './gold-text';
 import { LinkPreview } from './link-preview';
 import { MagnifierImage } from './magnifier-image';
 import { ManuscriptDisplay } from './manuscript-display';
+import { MartianCredit } from './martian-credit';
 import { Quote } from './quote';
 import { remarkSearchBlocks } from '@/lib/search-blocks';
 import { RuneFigure, RuneGrid } from './rune-figure';
@@ -50,6 +51,7 @@ const mdxComponents = {
   DefinitionItem,
   HashVerification,
   ManuscriptDisplay,
+  MartianCredit,
   EvidencePoint,
   EvidenceGroup,
   Callout,

--- a/components/mdx/martian-credit.tsx
+++ b/components/mdx/martian-credit.tsx
@@ -143,8 +143,16 @@ function MartianOrbitMark() {
           x2="0"
           y2="-25"
         >
-          <stop offset="0%" stopColor="var(--martian-dot-trail, var(--gold-bright))" stopOpacity="0.82" />
-          <stop offset="100%" stopColor="var(--martian-dot-trail, var(--gold-bright))" stopOpacity="0" />
+          <stop
+            offset="0%"
+            stopColor="var(--martian-dot-trail, var(--gold-bright))"
+            stopOpacity="0.82"
+          />
+          <stop
+            offset="100%"
+            stopColor="var(--martian-dot-trail, var(--gold-bright))"
+            stopOpacity="0"
+          />
         </linearGradient>
         <linearGradient
           id={ids.trailDeimos}
@@ -204,13 +212,7 @@ function MartianOrbitMark() {
           strokeLinecap="round"
           strokeWidth="1.6"
         />
-        <rect
-          x="23"
-          y="-2"
-          width="4"
-          height="4"
-          fill="var(--martian-dot, var(--gold-bright))"
-        />
+        <rect x="23" y="-2" width="4" height="4" fill="var(--martian-dot, var(--gold-bright))" />
       </g>
 
       <g>

--- a/components/mdx/martian-credit.tsx
+++ b/components/mdx/martian-credit.tsx
@@ -1,0 +1,260 @@
+'use client';
+
+import * as Dialog from '@radix-ui/react-dialog';
+import { ExternalLink, X } from 'lucide-react';
+import * as React from 'react';
+
+const BAYER_4: ReadonlyArray<ReadonlyArray<number>> = [
+  [0, 8, 2, 10],
+  [12, 4, 14, 6],
+  [3, 11, 1, 9],
+  [15, 7, 13, 5],
+];
+
+const DISC_R_MAX = 50;
+const DISC_R_BRIGHT_END = 32;
+const DISC_R_SOLID_END = 36;
+const CELL_SIZE = 2;
+
+type CellPhase = 'bright' | 'dark';
+
+type Cell = {
+  x: number;
+  y: number;
+  phase: CellPhase;
+};
+
+function computeDiscCells(): Cell[] {
+  const cells: Cell[] = [];
+
+  for (let y = -DISC_R_MAX; y < DISC_R_MAX; y += CELL_SIZE) {
+    for (let x = -DISC_R_MAX; x < DISC_R_MAX; x += CELL_SIZE) {
+      const cx = x + CELL_SIZE / 2;
+      const cy = y + CELL_SIZE / 2;
+      const dist = Math.hypot(cx, cy);
+      if (dist > DISC_R_MAX) continue;
+
+      const bayerX = Math.floor((x + DISC_R_MAX) / CELL_SIZE) % 4;
+      const bayerY = Math.floor((y + DISC_R_MAX) / CELL_SIZE) % 4;
+      const threshold = BAYER_4[bayerY][bayerX] / 16;
+      let phase: CellPhase | null = null;
+
+      if (dist < DISC_R_BRIGHT_END) {
+        const intensity = 1 - dist / DISC_R_BRIGHT_END;
+        phase = threshold < intensity ? 'bright' : 'dark';
+      } else if (dist < DISC_R_SOLID_END) {
+        phase = 'dark';
+      } else {
+        const intensity = 1 - (dist - DISC_R_SOLID_END) / (DISC_R_MAX - DISC_R_SOLID_END);
+        if (threshold < intensity) phase = 'dark';
+      }
+
+      if (phase) cells.push({ x, y, phase });
+    }
+  }
+
+  return cells;
+}
+
+const DISC_CELLS = computeDiscCells();
+
+/**
+ * A retinted Martian Engineering orbit mark adapted for the Elden Glass palette.
+ */
+function MartianOrbitMark() {
+  const rawId = React.useId();
+  const id = rawId.replace(/:/g, '');
+  const ids = {
+    trailPhobos: `${id}-tp`,
+    trailDeimos: `${id}-td`,
+  };
+
+  return (
+    <svg
+      className="block h-9 w-9 overflow-visible"
+      viewBox="-50 -50 100 100"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <defs>
+        <linearGradient
+          id={ids.trailPhobos}
+          gradientUnits="userSpaceOnUse"
+          x1="25"
+          y1="0"
+          x2="0"
+          y2="-25"
+        >
+          <stop offset="0%" stopColor="var(--gold-bright)" stopOpacity="0.82" />
+          <stop offset="100%" stopColor="var(--gold-bright)" stopOpacity="0" />
+        </linearGradient>
+        <linearGradient
+          id={ids.trailDeimos}
+          gradientUnits="userSpaceOnUse"
+          x1="40"
+          y1="0"
+          x2="0"
+          y2="-40"
+        >
+          <stop offset="0%" stopColor="var(--paper-dim)" stopOpacity="0.68" />
+          <stop offset="100%" stopColor="var(--paper-dim)" stopOpacity="0" />
+        </linearGradient>
+      </defs>
+
+      <g shapeRendering="crispEdges">
+        {DISC_CELLS.map((cell, index) => (
+          <rect
+            key={index}
+            x={cell.x}
+            y={cell.y}
+            width={CELL_SIZE}
+            height={CELL_SIZE}
+            fill={cell.phase === 'bright' ? 'var(--pane)' : 'var(--ink)'}
+          />
+        ))}
+      </g>
+
+      <text
+        x="0"
+        y="-3"
+        textAnchor="middle"
+        dominantBaseline="central"
+        className="select-none fill-[var(--gold)] font-mono text-[36px] font-bold"
+      >
+        m
+      </text>
+
+      <g>
+        <animateTransform
+          attributeName="transform"
+          type="rotate"
+          from="0 0 0"
+          to="360 0 0"
+          dur="5s"
+          repeatCount="indefinite"
+        />
+        <path
+          d="M 25 0 A 25 25 0 0 0 0 -25"
+          fill="none"
+          stroke={`url(#${ids.trailPhobos})`}
+          strokeLinecap="round"
+          strokeWidth="1.6"
+        />
+        <rect x="23" y="-2" width="4" height="4" fill="var(--gold-bright)" />
+      </g>
+
+      <g>
+        <animateTransform
+          attributeName="transform"
+          type="rotate"
+          from="0 0 0"
+          to="360 0 0"
+          dur="10s"
+          repeatCount="indefinite"
+        />
+        <path
+          d="M 40 0 A 40 40 0 0 0 0 -40"
+          fill="none"
+          stroke={`url(#${ids.trailDeimos})`}
+          strokeLinecap="round"
+          strokeWidth="1.4"
+        />
+        <g transform="translate(40, 0)">
+          <g>
+            <animateTransform
+              attributeName="transform"
+              type="rotate"
+              from="0 0 0"
+              to="-360 0 0"
+              dur="10s"
+              repeatCount="indefinite"
+            />
+            <text
+              x="0"
+              y="-2"
+              textAnchor="middle"
+              dominantBaseline="central"
+              className="select-none fill-[var(--paper-dim)] font-mono text-[22px] font-medium"
+            >
+              e
+            </text>
+          </g>
+        </g>
+      </g>
+    </svg>
+  );
+}
+
+/**
+ * Coy author-page attribution for the Martian Engineering site build.
+ */
+export function MartianCredit() {
+  return (
+    <Dialog.Root>
+      <div className="not-prose mt-16 flex justify-end border-t border-[var(--crack)] pt-6">
+        <Dialog.Trigger asChild>
+          <button
+            type="button"
+            className="group inline-flex items-center gap-2 rounded-sm border border-[var(--glass-edge)] bg-[rgb(var(--bg-secondary-rgb)/0.45)] px-2.5 py-1.5 text-left font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--paper-dimmer)] opacity-75 transition hover:border-[var(--gold-dim)] hover:text-[var(--paper-dim)] hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--gold-dim)]"
+            aria-label="About the Martian Engineering build"
+          >
+            <MartianOrbitMark />
+            <span className="leading-tight">
+              quietly powered by
+              <span className="block text-[var(--gold)]">Martian.Engineering</span>
+            </span>
+          </button>
+        </Dialog.Trigger>
+      </div>
+
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-[90] bg-[rgba(0,0,0,0.78)] backdrop-blur-sm data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-[100] w-[min(34rem,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 overflow-hidden border border-[var(--gold-dim)] bg-[var(--ink-2)] shadow-panel outline-none data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95">
+          <div className="flex items-start justify-between gap-4 border-b border-[var(--pane-edge)] bg-[var(--pane)] px-5 py-4">
+            <Dialog.Title className="font-serif text-2xl leading-none text-[var(--gold)]">
+              A small Martian machine
+            </Dialog.Title>
+            <Dialog.Close className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-[var(--border-emphasis)] bg-[rgb(var(--bg-primary-rgb)/0.75)] text-[var(--paper-dim)] transition hover:text-[var(--gold-bright)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--gold-dim)]">
+              <X className="h-4 w-4" />
+              <span className="sr-only">Close</span>
+            </Dialog.Close>
+          </div>
+
+          <div className="space-y-4 px-5 py-5 font-serif text-[17px] leading-relaxed text-[var(--paper-dim)]">
+            <p>
+              Martian Engineering built this site pro bono because the argument was too strange, too
+              specific, and too alive to leave in a pile of notes.
+            </p>
+            <p>
+              The site is a custom Next.js instrument: authored MDX drives the content tree,
+              navigation, contents, sitemap, and LLM surfaces; structured item cards power the
+              Gatherer and the Duchamp works view; MiniSearch indexes prose and cards through one
+              local search layer; result links land on addressable prose blocks instead of vague
+              pages.
+            </p>
+            <p>
+              The attestation pieces, fedwiki import/export scripts, local manuscript checks, and
+              quiet little search behaviors are all part of the same idea: make the scholarship feel
+              like a working apparatus, not a brochure.
+            </p>
+            <p>
+              The mark is a machine too: a Bayer-dithered planet with an <code>m</code> at center, a
+              quick dot, and a slower <code>e</code> orbiting back into alignment.
+            </p>
+            <div className="border-t border-[var(--pane-edge)] pt-4">
+              <a
+                href="https://martian.engineering"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--gold)] no-underline transition hover:text-[var(--gold-bright)]"
+              >
+                martian.engineering
+                <ExternalLink className="h-3.5 w-3.5" />
+              </a>
+            </div>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/components/mdx/martian-credit.tsx
+++ b/components/mdx/martian-credit.tsx
@@ -58,24 +58,82 @@ function computeDiscCells(): Cell[] {
 
 const DISC_CELLS = computeDiscCells();
 
+function usePrefersReducedMotion(): boolean {
+  const [prefersReducedMotion, setPrefersReducedMotion] = React.useState(true);
+
+  React.useEffect(() => {
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const syncPreference = () => setPrefersReducedMotion(mediaQuery.matches);
+
+    syncPreference();
+    mediaQuery.addEventListener('change', syncPreference);
+    return () => mediaQuery.removeEventListener('change', syncPreference);
+  }, []);
+
+  return prefersReducedMotion;
+}
+
 /**
  * A retinted Martian Engineering orbit mark adapted for the Elden Glass palette.
  */
 function MartianOrbitMark() {
+  const prefersReducedMotion = usePrefersReducedMotion();
   const rawId = React.useId();
   const id = rawId.replace(/:/g, '');
   const ids = {
     trailPhobos: `${id}-tp`,
     trailDeimos: `${id}-td`,
+    transitionReset: `${id}-transition-reset`,
   };
 
   return (
     <svg
+      id={ids.transitionReset}
       className="block h-9 w-9 overflow-visible"
       viewBox="-50 -50 100 100"
       xmlns="http://www.w3.org/2000/svg"
       aria-hidden="true"
     >
+      <style>
+        {`
+          #${ids.transitionReset},
+          #${ids.transitionReset} * {
+            transition-property: none;
+            transition-duration: 0s;
+            text-transform: none;
+          }
+
+          #${ids.transitionReset} {
+            display: block;
+            overflow: visible;
+          }
+
+          #${ids.transitionReset} text {
+            font-variant-caps: normal;
+            font-variant-ligatures: none;
+            letter-spacing: normal;
+            line-height: normal;
+            text-decoration: none;
+            text-rendering: geometricPrecision;
+            white-space: pre;
+          }
+
+          #${ids.transitionReset} path,
+          #${ids.transitionReset} rect,
+          #${ids.transitionReset} text {
+            vector-effect: none;
+          }
+
+          #${ids.transitionReset} rect,
+          #${ids.transitionReset} text,
+          #${ids.transitionReset} stop {
+            transition-property: fill, stop-color;
+            transition-duration: 260ms;
+            transition-timing-function: ease-out;
+          }
+        `}
+      </style>
+
       <defs>
         <linearGradient
           id={ids.trailPhobos}
@@ -85,8 +143,8 @@ function MartianOrbitMark() {
           x2="0"
           y2="-25"
         >
-          <stop offset="0%" stopColor="var(--gold-bright)" stopOpacity="0.82" />
-          <stop offset="100%" stopColor="var(--gold-bright)" stopOpacity="0" />
+          <stop offset="0%" stopColor="var(--martian-dot-trail, var(--gold-bright))" stopOpacity="0.82" />
+          <stop offset="100%" stopColor="var(--martian-dot-trail, var(--gold-bright))" stopOpacity="0" />
         </linearGradient>
         <linearGradient
           id={ids.trailDeimos}
@@ -96,8 +154,8 @@ function MartianOrbitMark() {
           x2="0"
           y2="-40"
         >
-          <stop offset="0%" stopColor="var(--paper-dim)" stopOpacity="0.68" />
-          <stop offset="100%" stopColor="var(--paper-dim)" stopOpacity="0" />
+          <stop offset="0%" stopColor="var(--martian-moon, var(--paper-dim))" stopOpacity="0.68" />
+          <stop offset="100%" stopColor="var(--martian-moon, var(--paper-dim))" stopOpacity="0" />
         </linearGradient>
       </defs>
 
@@ -109,7 +167,11 @@ function MartianOrbitMark() {
             y={cell.y}
             width={CELL_SIZE}
             height={CELL_SIZE}
-            fill={cell.phase === 'bright' ? 'var(--pane)' : 'var(--ink)'}
+            fill={
+              cell.phase === 'bright'
+                ? 'var(--martian-disc-bright, var(--border-emphasis))'
+                : 'var(--martian-disc-dark, var(--ink-3))'
+            }
           />
         ))}
       </g>
@@ -125,14 +187,16 @@ function MartianOrbitMark() {
       </text>
 
       <g>
-        <animateTransform
-          attributeName="transform"
-          type="rotate"
-          from="0 0 0"
-          to="360 0 0"
-          dur="5s"
-          repeatCount="indefinite"
-        />
+        {!prefersReducedMotion && (
+          <animateTransform
+            attributeName="transform"
+            type="rotate"
+            from="0 0 0"
+            to="360 0 0"
+            dur="5s"
+            repeatCount="indefinite"
+          />
+        )}
         <path
           d="M 25 0 A 25 25 0 0 0 0 -25"
           fill="none"
@@ -140,18 +204,26 @@ function MartianOrbitMark() {
           strokeLinecap="round"
           strokeWidth="1.6"
         />
-        <rect x="23" y="-2" width="4" height="4" fill="var(--gold-bright)" />
+        <rect
+          x="23"
+          y="-2"
+          width="4"
+          height="4"
+          fill="var(--martian-dot, var(--gold-bright))"
+        />
       </g>
 
       <g>
-        <animateTransform
-          attributeName="transform"
-          type="rotate"
-          from="0 0 0"
-          to="360 0 0"
-          dur="10s"
-          repeatCount="indefinite"
-        />
+        {!prefersReducedMotion && (
+          <animateTransform
+            attributeName="transform"
+            type="rotate"
+            from="0 0 0"
+            to="360 0 0"
+            dur="10s"
+            repeatCount="indefinite"
+          />
+        )}
         <path
           d="M 40 0 A 40 40 0 0 0 0 -40"
           fill="none"
@@ -161,20 +233,22 @@ function MartianOrbitMark() {
         />
         <g transform="translate(40, 0)">
           <g>
-            <animateTransform
-              attributeName="transform"
-              type="rotate"
-              from="0 0 0"
-              to="-360 0 0"
-              dur="10s"
-              repeatCount="indefinite"
-            />
+            {!prefersReducedMotion && (
+              <animateTransform
+                attributeName="transform"
+                type="rotate"
+                from="0 0 0"
+                to="-360 0 0"
+                dur="10s"
+                repeatCount="indefinite"
+              />
+            )}
             <text
               x="0"
               y="-2"
               textAnchor="middle"
               dominantBaseline="central"
-              className="select-none fill-[var(--paper-dim)] font-mono text-[22px] font-medium"
+              className="select-none fill-[var(--martian-moon,var(--paper-dim))] font-mono text-[22px] font-medium"
             >
               e
             </text>
@@ -195,12 +269,12 @@ export function MartianCredit() {
         <Dialog.Trigger asChild>
           <button
             type="button"
-            className="group inline-flex items-center gap-2 rounded-sm border border-[var(--glass-edge)] bg-[rgb(var(--bg-secondary-rgb)/0.45)] px-2.5 py-1.5 text-left font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--paper-dimmer)] opacity-75 transition hover:border-[var(--gold-dim)] hover:text-[var(--paper-dim)] hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--gold-dim)]"
+            className="group inline-flex cursor-pointer items-center gap-2 rounded-sm border border-[var(--glass-edge)] bg-[rgb(var(--bg-secondary-rgb)/0.45)] px-2.5 py-1.5 text-left font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--paper-dimmer)] opacity-75 transition [--martian-disc-bright:var(--border-emphasis)] [--martian-disc-dark:var(--ink-3)] [--martian-dot:var(--gold-bright)] [--martian-dot-trail:var(--gold-bright)] [--martian-moon:var(--paper-dim)] hover:border-[var(--gold-dim)] hover:text-[var(--paper-dim)] hover:opacity-100 hover:[--martian-disc-bright:#5a4a32] hover:[--martian-disc-dark:#211d18] hover:[--martian-dot:var(--paper)] hover:[--martian-dot-trail:var(--paper)] hover:[--martian-moon:var(--paper)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--gold-dim)] focus-visible:[--martian-disc-bright:#5a4a32] focus-visible:[--martian-disc-dark:#211d18] focus-visible:[--martian-dot:var(--paper)] focus-visible:[--martian-dot-trail:var(--paper)] focus-visible:[--martian-moon:var(--paper)]"
             aria-label="About the Martian Engineering build"
           >
             <MartianOrbitMark />
             <span className="leading-tight">
-              quietly powered by
+              proudly supported by
               <span className="block text-[var(--gold)]">Martian.Engineering</span>
             </span>
           </button>
@@ -222,24 +296,26 @@ export function MartianCredit() {
 
           <div className="space-y-4 px-5 py-5 font-serif text-[17px] leading-relaxed text-[var(--paper-dim)]">
             <p>
-              Martian Engineering built this site pro bono because the argument was too strange, too
-              specific, and too alive to leave in a pile of notes.
-            </p>
-            <p>
-              The site is a custom Next.js instrument: authored MDX drives the content tree,
+              This site is a custom Next.js instrument. Authored MDX drives the content tree,
               navigation, contents, sitemap, and LLM surfaces; structured item cards power the
-              Gatherer and the Duchamp works view; MiniSearch indexes prose and cards through one
-              local search layer; result links land on addressable prose blocks instead of vague
+              Gatherer and Duchamp works view. MiniSearch indexes prose and cards through one local
+              search layer, and result links land on addressable prose blocks instead of vague
               pages.
             </p>
             <p>
-              The attestation pieces, fedwiki import/export scripts, local manuscript checks, and
-              quiet little search behaviors are all part of the same idea: make the scholarship feel
-              like a working apparatus, not a brochure.
+              The argument is intentionally sprawling, so the site is optimized for agent experience
+              as well as human review. Full local agents, browser-based LLM harnesses, and stranger
+              rigs can reach the material, traverse it, and present it without scraping around the
+              edges.
             </p>
             <p>
-              The mark is a machine too: a Bayer-dithered planet with an <code>m</code> at center, a
-              quick dot, and a slower <code>e</code> orbiting back into alignment.
+              Every piece follows the same principle: make the scholarship feel like a working
+              apparatus, perhaps even a delay, rather than a brochure.
+            </p>
+            <p>
+              Martian Engineering built this site pro bono because the argument was too strange, too
+              specific, and too alive to leave in a pile of notes. The footer you clicked is a
+              machine too: a Bayer-dithered planet-in-starfield with the Martian signature in orbit.
             </p>
             <div className="border-t border-[var(--pane-edge)] pt-4">
               <a

--- a/content/pages/author/about.mdx
+++ b/content/pages/author/about.mdx
@@ -45,3 +45,5 @@ Elden Ring and Marcel Duchamp's work are inherently _pataphysical_—operating a
 Current AI operates on statistical pattern matching. It finds laws—what usually happens, what's most likely, what the training data suggests. It cannot find exceptions. It cannot operate where contradictions are true. It cannot navigate the space where "there is no solution because there is no problem."
 
 For AI to solve problems like these would require primitives that operate pataphysically. Semantic operators that find the swerve, not the average. A runtime where exceptions are first-class objects.
+
+<MartianCredit />


### PR DESCRIPTION
## What

Adds a quiet Martian Engineering credit to the tail of the About the Author page, using a retinted local version of the powered-by orbit mark and a modal explaining the build.

## Why

The site should acknowledge the Martian Engineering work without turning the author page into a contractor billboard. The credit stays small and coy, while the modal gives interested readers a concise account of the custom machinery behind the site and the pro bono nature of the work.

## Changes

- Add Martian credit component
- Register it for MDX
- Append it to author page
- Retint logo to site palette
- Add build-process modal copy
- Preserve SVG orbit animation
- Respect reduced-motion preference
- Tune subtle hover highlighting

## Testing

- npm run typecheck
- Captured local /author/about screenshot with Chrome
- Inspected the live footer on localhost:4000
