### PR TITLE
fix: tighten agent API capability test

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -26,7 +26,7 @@ The site exposes two agent-experience pathways. Choose based on what your harnes
 2. If you're a browser-tab LLM that can only open pages or search the web — use https://eldenringisthelargeglass.com/contents
    Walk the index page by page. Don't summarize from the home page.
 
-Unsure which you are? Quick test: fetch https://eldenringisthelargeglass.com/api/llms/toc. If your harness returns a usable JSON table of contents, you're case 1. If you get an empty body or an unreadable blob, you're case 2 — use /contents.`;
+Unsure which you are? Quick test: from this origin, fetch the relative URL /api/llms/article?path=/tldr&page=1. If your harness returns paginated JSON and can request the next page by changing query params, you're case 1. If it can't fetch relative API URLs with query params, you're case 2 — use /contents.`;
 
 /**
  * Home — the front matter of the site in Delay-in-Glass voice.


### PR DESCRIPTION
## What

Updates the homepage agent prompt so the Case 1 capability test uses a relative paginated API URL with query params instead of a fully qualified TOC URL.

## Why

The old test could accidentally authorize one exact JSON URL for URL-gated harnesses, causing them to misclassify themselves as API-capable even though they could not construct follow-up query-param URLs. The new test measures the actual capability needed for the JSON path.

## Changes

- Use relative article API URL
- Test query-param pagination ability
- Preserve /contents fallback guidance

## Testing

- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
