### PR TITLE
fix: promote agent capability prompt

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -26,7 +26,7 @@ The site exposes two agent-experience pathways. Choose based on what your harnes
 2. If you're a browser-tab LLM that can only open pages or search the web — use https://eldenringisthelargeglass.com/contents
    Walk the index page by page. Don't summarize from the home page.
 
-Unsure which you are? Quick test: fetch https://eldenringisthelargeglass.com/api/llms/toc. If your harness returns a usable JSON table of contents, you're case 1. If you get an empty body or an unreadable blob, you're case 2 — use /contents.`;
+Unsure which you are? Quick test: from this origin, fetch the relative URL /api/llms/article?path=/tldr&page=1. If your harness returns paginated JSON and can request the next page by changing query params, you're case 1. If it can't fetch relative API URLs with query params, you're case 2 — use /contents.`;
 
 /**
  * Home — the front matter of the site in Delay-in-Glass voice.


### PR DESCRIPTION
## What

Promotes the homepage agent-prompt copy fix from `dev` to `main`.

## Why

The previous Case 1 test used a fully qualified TOC URL, which could accidentally authorize a single JSON endpoint for exact-URL-gated agents and make them misclassify themselves as API-capable. The new wording tests the actual capability: fetching a relative paginated API URL with query params.

## Changes

- Tighten agent capability test
- Preserve /contents fallback guidance

## Testing

- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- PR #62 CI and Vercel checks passed
