### PR TITLE
docs: Promote style-system audit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,10 +214,13 @@ hand-authored nav tree.
 
 Global style tokens live in `app/globals.css`.
 
-Use existing tokens and shared components before adding one-off colors,
-surfaces, borders, shadows, or type styling. If a new visual role is genuinely
-needed, add a named token in `app/globals.css` and use that token from
-components.
+The full style-system contract lives in `docs/style-system.md`. Follow it for
+new work.
+
+Use canonical Delay in Glass tokens and shared components before adding
+one-off colors, surfaces, borders, shadows, or type styling. If a new visual
+role is genuinely needed, add one named token in `app/globals.css` and use that
+token from components.
 
 Do not introduce `var(--...)` consumers without defining the token in
 `app/globals.css`. `npm run check:tokens` audits this, and `npm run build`
@@ -226,6 +229,10 @@ runs the audit before compiling.
 Tailwind utilities are still appropriate for layout, spacing, responsive
 behavior, state, and component-local composition. The boundary is visual
 identity: colors and recurring surfaces should come from the token system.
+
+Run `npm run audit:styles` to review legacy-token usage, raw colors, static
+inline styles, and hand-rolled surfaces. The audit is advisory until a category
+is explicitly promoted into CI.
 
 ## Content Authoring Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,10 +214,13 @@ hand-authored nav tree.
 
 Global style tokens live in `app/globals.css`.
 
-Use existing tokens and shared components before adding one-off colors,
-surfaces, borders, shadows, or type styling. If a new visual role is genuinely
-needed, add a named token in `app/globals.css` and use that token from
-components.
+The full style-system contract lives in `docs/style-system.md`. Follow it for
+new work.
+
+Use canonical Delay in Glass tokens and shared components before adding
+one-off colors, surfaces, borders, shadows, or type styling. If a new visual
+role is genuinely needed, add one named token in `app/globals.css` and use that
+token from components.
 
 Do not introduce `var(--...)` consumers without defining the token in
 `app/globals.css`. `npm run check:tokens` audits this, and `npm run build`
@@ -226,6 +229,10 @@ runs the audit before compiling.
 Tailwind utilities are still appropriate for layout, spacing, responsive
 behavior, state, and component-local composition. The boundary is visual
 identity: colors and recurring surfaces should come from the token system.
+
+Run `npm run audit:styles` to review legacy-token usage, raw colors, static
+inline styles, and hand-rolled surfaces. The audit is advisory until a category
+is explicitly promoted into CI.
 
 ## Content Authoring Rules
 

--- a/docs/style-system.md
+++ b/docs/style-system.md
@@ -1,0 +1,140 @@
+# Elden Glass Style System
+
+This repo uses a single visual language: Delay in Glass. The goal is not to
+offer several equivalent styling paths. The goal is to make the right path
+obvious enough that new work does not create fresh visual dialects.
+
+## Source Of Truth
+
+The source of truth is `app/globals.css`.
+
+It owns:
+
+- the canonical color tokens
+- the font tokens
+- the type scale tokens
+- the rule and pane tokens
+- the named Delay in Glass classes
+
+Component code may compose those primitives, but it must not invent a parallel
+palette, type system, or surface system.
+
+## Canonical Tokens
+
+Use these tokens for new visual identity work:
+
+| Role              | Tokens                                                                                                                      |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| Ground            | `--ink`, `--ink-2`, `--ink-3`                                                                                               |
+| Surfaces          | `--pane`, `--pane-edge`, `--glass`, `--glass-edge`                                                                          |
+| Rules             | `--crack`, `--crack-strong`, `--rule`, `--rule-strong`, `--rule-gold`                                                       |
+| Text              | `--paper`, `--paper-dim`, `--paper-dimmer`, `--paper-dimmest`                                                               |
+| Accent            | `--gold`, `--gold-dim`, `--gold-bright`                                                                                     |
+| Secondary accents | `--rust`, `--rust-dim`, `--glass-blue`, `--glass-blue-dim`, `--verdigris`                                                   |
+| Fonts             | `--font-serif`, `--font-sans`, `--font-mono`                                                                                |
+| Type scale        | `--fs-micro`, `--fs-cap`, `--fs-spec`, `--fs-body`, `--fs-lead`, `--fs-h4`, `--fs-h3`, `--fs-h2`, `--fs-h1`, `--fs-display` |
+
+Legacy aliases such as `--bg-primary`, `--text-primary`,
+`--accent-gold`, and `--border-subtle` exist only to keep older components
+rendering while they are migrated. New code must not use them.
+
+Raw colors belong in `app/globals.css`. Component files should not contain
+hex colors, `rgb()`, `rgba()`, `hsl()`, `bg-white`, `text-red-400`, or similar
+parallel palette choices unless the value is truly data-rendered output.
+
+## Component Primitives
+
+Use named primitives before hand-rolling equivalent Tailwind and token
+combinations.
+
+| Need                                 | Use                            |
+| ------------------------------------ | ------------------------------ |
+| Bounded content surface              | `Pane` from `components/delay` |
+| Solid bounded surface                | `<Pane solid>`                 |
+| Figure or reproduction               | `Plate`                        |
+| Editorial lead paragraph             | `Lead`                         |
+| Apparatus label                      | `Eyebrow`                      |
+| Coordinate, hash, or technical value | `Spec`                         |
+| Caption or small note                | `Cap`                          |
+| Pull quote                           | `PullQuote`                    |
+| Margin note                          | `MarginNote` or `AsideInline`  |
+| Attestation card                     | `AttestCard`                   |
+| Ornamental rule                      | `Crackline`                    |
+
+The older `glass-card` class is legacy. Do not add new `glass-card` call sites.
+When touching a file that already uses it, prefer converting that local surface
+to `Pane` or a more specific Delay primitive.
+
+## Tailwind Boundary
+
+Tailwind remains the layout language.
+
+Use Tailwind for:
+
+- flex, grid, gap, margin, padding
+- width, height, position, overflow
+- breakpoints and responsive state
+- interaction state wiring
+- dense control sizing when no Delay primitive applies
+
+Do not use Tailwind to create new visual identity:
+
+- no ad hoc color utilities
+- no one-off surface recipes
+- no new rounded-card vocabulary
+- no shadow vocabulary outside existing tokens/utilities
+- no arbitrary type system for editorial content
+
+If a visual role repeats, make it a named Delay primitive or add one canonical
+token in `app/globals.css`.
+
+## Inline Styles
+
+Static visual styling does not belong in `style={{ ... }}`.
+
+Inline styles are acceptable only for:
+
+- computed geometry
+- SVG coordinates and measurements
+- dynamic transforms
+- dynamic CSS variables passed into an existing class
+- third-party integration seams that cannot express the value otherwise
+
+Inline styles are not acceptable for static color, border, font, radius, or
+surface decisions.
+
+## Conversion Rule
+
+Do not run a blind find-and-replace across the repo.
+
+When touching a component for product work:
+
+1. Convert the visual identity in that component to canonical tokens or Delay
+   primitives.
+2. Keep layout utilities as Tailwind.
+3. Remove static inline visual styling in that component.
+4. Leave unrelated files alone.
+
+If conversion would alter a page materially, stop and make it a dedicated
+reviewable change.
+
+## Audit
+
+Run:
+
+```bash
+npm run audit:styles
+```
+
+The audit is intentionally non-failing. It reports the current amount of style
+drift so we can make it smaller over time:
+
+- legacy token usage
+- inline style objects
+- raw color literals
+- non-system Tailwind color utilities
+- hand-rolled surfaces
+- existing Delay primitive usage
+
+Promote a category to CI only after the baseline is low enough that failures
+are actionable.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "check:generated": "npm run check:critique-assets && npm run check:manuscripts",
     "check:manuscripts": "node scripts/sync-manuscripts.js --check",
     "check:tokens": "node scripts/check-css-tokens.js",
+    "audit:styles": "node scripts/audit-style-system.js",
     "lint": "eslint . --max-warnings=0",
     "lint:actions": "github-actionlint",
     "typecheck": "next typegen && tsc --noEmit -p tsconfig.typecheck.json",

--- a/scripts/audit-style-system.js
+++ b/scripts/audit-style-system.js
@@ -1,0 +1,287 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = process.cwd();
+const TOKEN_FILE = path.join(ROOT, 'app', 'globals.css');
+const SCAN_TARGETS = ['app', 'components', 'content', 'lib', 'scripts', 'tailwind.config.mjs'];
+const SCAN_EXTENSIONS = new Set(['.css', '.js', '.jsx', '.md', '.mdx', '.ts', '.tsx', '.mjs']);
+const IGNORED_DIRS = new Set(['.git', '.next', '.turbo', 'node_modules']);
+const EXCLUDED_FILES = new Set([path.relative(ROOT, TOKEN_FILE), 'scripts/audit-style-system.js']);
+
+const LEGACY_TOKENS = [
+  '--font-crimson',
+  '--font-inter',
+  '--bg-primary',
+  '--bg-secondary',
+  '--bg-tertiary',
+  '--bg-elevated',
+  '--text-primary',
+  '--text-secondary',
+  '--text-tertiary',
+  '--accent-gold',
+  '--accent-gold-hover',
+  '--accent-blue',
+  '--accent-purple',
+  '--accent-muted',
+  '--accent-red',
+  '--border-subtle',
+  '--border-emphasis',
+  '--success-green',
+  '--bg-primary-rgb',
+  '--bg-secondary-rgb',
+  '--accent-gold-rgb',
+  '--accent-blue-rgb',
+  '--accent-purple-rgb',
+  '--success-green-rgb',
+];
+
+const DELAY_PRIMITIVES = [
+  'pane',
+  'pane--solid',
+  'plate',
+  'plate-no',
+  'plate-cap',
+  'eyebrow',
+  'eyebrow--gold',
+  'eyebrow--rust',
+  'eyebrow--blue',
+  'spec',
+  'cap',
+  'lead',
+  'quote',
+  'quote-body',
+  'quote-attr',
+  'margin-note',
+  'attest',
+  'correspondence',
+  'crackline',
+  'crackline--gold',
+  'seal-strip',
+  'stair',
+  'delay-h1',
+  'delay-h2',
+  'delay-h3',
+  'delay-h4',
+];
+
+const COLOR_UTILITY_PATTERN =
+  /\b(?:hover:|focus:|focus-visible:|active:|disabled:|group-hover:|sm:|md:|lg:|xl:|2xl:|dark:)*(?:bg|text|border|ring|from|via|to|fill|stroke|decoration|placeholder)-((?:slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-\d{2,3}|black|white)\b/g;
+
+function walkFiles(target, files = []) {
+  const fullTarget = path.join(ROOT, target);
+  if (!fs.existsSync(fullTarget)) {
+    return files;
+  }
+
+  const stat = fs.statSync(fullTarget);
+  if (stat.isFile()) {
+    if (SCAN_EXTENSIONS.has(path.extname(fullTarget))) {
+      files.push(fullTarget);
+    }
+    return files;
+  }
+
+  for (const entry of fs.readdirSync(fullTarget, { withFileTypes: true })) {
+    const entryPath = path.join(fullTarget, entry.name);
+    if (entry.isDirectory()) {
+      if (!IGNORED_DIRS.has(entry.name)) {
+        walkFiles(path.relative(ROOT, entryPath), files);
+      }
+      continue;
+    }
+
+    if (entry.isFile() && SCAN_EXTENSIONS.has(path.extname(entry.name))) {
+      files.push(entryPath);
+    }
+  }
+
+  return files;
+}
+
+function lineNumberFor(source, index) {
+  return source.slice(0, index).split('\n').length;
+}
+
+function compactSnippet(line) {
+  return line.trim().replace(/\s+/g, ' ').slice(0, 160);
+}
+
+function lineAt(source, lineNumber) {
+  return source.split('\n')[lineNumber - 1] ?? '';
+}
+
+function pushMatch(results, kind, file, line, value, source) {
+  results.push({
+    kind,
+    file,
+    line,
+    value,
+    source: compactSnippet(lineAt(source, line)),
+  });
+}
+
+function collectRegexMatches(source, regex, callback) {
+  regex.lastIndex = 0;
+  for (const match of source.matchAll(regex)) {
+    callback(match);
+  }
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function auditFile(file) {
+  const relativeFile = path.relative(ROOT, file);
+  const source = fs.readFileSync(file, 'utf8');
+  const results = [];
+
+  if (!EXCLUDED_FILES.has(relativeFile)) {
+    const legacyAlternates = [...LEGACY_TOKENS]
+      .sort((left, right) => right.length - left.length)
+      .map(escapeRegExp)
+      .join('|');
+    const legacyPattern = new RegExp(`var\\(\\s*(${legacyAlternates})(?=[\\s,)])`, 'g');
+    collectRegexMatches(source, legacyPattern, (match) => {
+      pushMatch(
+        results,
+        'legacy-token',
+        relativeFile,
+        lineNumberFor(source, match.index),
+        match[1],
+        source
+      );
+    });
+  }
+
+  if (!EXCLUDED_FILES.has(relativeFile)) {
+    collectRegexMatches(source, /style\s*=\s*\{\{/g, (match) => {
+      pushMatch(
+        results,
+        'inline-style',
+        relativeFile,
+        lineNumberFor(source, match.index),
+        'style={{ ... }}',
+        source
+      );
+    });
+  }
+
+  if (!EXCLUDED_FILES.has(relativeFile)) {
+    collectRegexMatches(source, /#[0-9A-Fa-f]{3,8}\b|\b(?:rgba?|hsla?)\(/g, (match) => {
+      pushMatch(
+        results,
+        'raw-color',
+        relativeFile,
+        lineNumberFor(source, match.index),
+        match[0],
+        source
+      );
+    });
+
+    collectRegexMatches(source, COLOR_UTILITY_PATTERN, (match) => {
+      pushMatch(
+        results,
+        'tailwind-color-utility',
+        relativeFile,
+        lineNumberFor(source, match.index),
+        match[0],
+        source
+      );
+    });
+  }
+
+  if (!EXCLUDED_FILES.has(relativeFile)) {
+    const lines = source.split('\n');
+    lines.forEach((line, index) => {
+      const namesSurface =
+        line.includes('glass-card') ||
+        (line.includes('border') && (line.includes('bg-[var(') || line.includes('bg-[rgb(var(')));
+      const alreadyDelayPrimitive = /\b(?:pane|plate|attest|quote|margin-note)\b/.test(line);
+      if (namesSurface && !alreadyDelayPrimitive) {
+        results.push({
+          kind: 'hand-rolled-surface',
+          file: relativeFile,
+          line: index + 1,
+          value: 'surface recipe',
+          source: compactSnippet(line),
+        });
+      }
+    });
+  }
+
+  const primitiveAlternates = [...DELAY_PRIMITIVES]
+    .sort((left, right) => right.length - left.length)
+    .map(escapeRegExp)
+    .join('|');
+  const primitivePattern = new RegExp(`\\b(${primitiveAlternates})\\b`, 'g');
+  collectRegexMatches(source, primitivePattern, (match) => {
+    if (!EXCLUDED_FILES.has(relativeFile)) {
+      pushMatch(
+        results,
+        'delay-primitive',
+        relativeFile,
+        lineNumberFor(source, match.index),
+        match[1],
+        source
+      );
+    }
+  });
+
+  return results;
+}
+
+function groupBy(items, key) {
+  const groups = new Map();
+  for (const item of items) {
+    const groupKey = item[key];
+    groups.set(groupKey, [...(groups.get(groupKey) ?? []), item]);
+  }
+  return groups;
+}
+
+function printCategory(title, items, options = {}) {
+  const { sampleLimit = 8, positive = false } = options;
+  const byFile = groupBy(items, 'file');
+  const label = positive ? 'present' : 'found';
+  console.log(`\n${title}: ${items.length} ${label} across ${byFile.size} files`);
+
+  if (items.length === 0) {
+    return;
+  }
+
+  const rankedFiles = [...byFile.entries()].sort((a, b) => b[1].length - a[1].length);
+  for (const [file, fileItems] of rankedFiles.slice(0, sampleLimit)) {
+    const first = fileItems[0];
+    console.log(`- ${file}: ${fileItems.length} (first ${first.line}: ${first.value})`);
+  }
+}
+
+const files = SCAN_TARGETS.flatMap((target) => walkFiles(target));
+const allResults = files.flatMap(auditFile);
+const byKind = groupBy(allResults, 'kind');
+
+const driftKinds = [
+  'legacy-token',
+  'inline-style',
+  'raw-color',
+  'tailwind-color-utility',
+  'hand-rolled-surface',
+];
+
+const driftTotal = driftKinds.reduce((total, kind) => total + (byKind.get(kind)?.length ?? 0), 0);
+
+console.log('[style-system-audit] Non-failing Delay in Glass drift report');
+console.log(`Scanned ${files.length} files.`);
+console.log(`Excluded canonical definitions: ${[...EXCLUDED_FILES].join(', ')}`);
+console.log(`Total drift signals: ${driftTotal}`);
+
+printCategory('Legacy token usages', byKind.get('legacy-token') ?? []);
+printCategory('Inline style objects', byKind.get('inline-style') ?? []);
+printCategory('Raw color literals', byKind.get('raw-color') ?? []);
+printCategory('Non-system Tailwind color utilities', byKind.get('tailwind-color-utility') ?? []);
+printCategory('Hand-rolled surfaces', byKind.get('hand-rolled-surface') ?? []);
+printCategory('Delay primitive usages', byKind.get('delay-primitive') ?? [], { positive: true });
+
+console.log('\nThis audit reports drift only; it does not fail CI.');


### PR DESCRIPTION
## What

This PR promotes the current `dev` branch to `main`, including the strict Delay in Glass style-system contract and advisory style drift audit from PR #64.

## Why

The style-system work establishes clear doctrine and measurable drift before we start converting legacy surfaces. Promoting it keeps `main` aligned with the reviewed `dev` baseline.

## Changes

- Promote style contract
- Promote advisory audit
- Promote agent doc pointers

## Testing

- PR #64 GitHub verify passed
- PR #64 Vercel passed
- `npm run audit:styles`
- `npm run check:tokens`
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
