### PR TITLE
Clean up item-card content and prose appraisal

### DIFF
--- a/content/critiques/composite-ai-appraisal.md
+++ b/content/critiques/composite-ai-appraisal.md
@@ -1,0 +1,83 @@
+---
+title: 'Composite AI Appraisal: The Strongest Objections'
+summary: 'A considered response to recurring AI-reader objections about Elden Glass: confirmation, pattern matching, evidentiary threshold, medium translation, and why the thesis is framed literally rather than as influence history.'
+targetUrl: 'https://eldenringisthelargeglass.com'
+targetTitle: 'Elden Glass'
+published: '2026-05-01'
+updated: '2026-05-01'
+---
+
+## Why this response exists
+
+Several AI-style appraisals of Elden Glass converge on the same discomfort: the thesis is specific, ambitious, and often persuasive at the level of pattern, but it asks readers to accept a literal hidden structure without the ordinary external assurances that art-historical or game-studies arguments often lean on. That objection is serious enough to deserve a direct answer.
+
+The strongest version is not "FromSoftware never confirmed this, therefore it is false." The site already rejects creator confirmation as the wrong evidentiary standard for an undisclosed secret. The stronger objection is methodological: **how should a reader distinguish hidden intentional structure from an unusually rich act of interpretation?**
+
+That is the right question.
+
+## The strongest objections
+
+### 1. The thesis can sound over-certain before the evidence has accumulated
+
+The homepage and Living Thesis intentionally state the claim in its strongest form: _Elden Ring_ is _The Large Glass_. That has rhetorical force, but it can also make a skeptical reader feel that the conclusion has arrived before the method.
+
+The answer is not to weaken the claim into "inspired by" or "shares themes with." That would misstate the argument. The better answer is to make the evidentiary threshold more visible: the thesis depends on accumulated specificity, not on any single resemblance. One correspondence is a metaphor. Ten may still be a reading. A dense, ordered system of named correspondences, following Duchamp's own technical notes, begins to require a different explanation.
+
+### 2. The reader needs help separating anchor correspondences from atmosphere
+
+Some correspondences carry more weight than others. The Chocolate Grinder, the Bride/Bachelor split, the Milky Way, the Malic Moulds, the Three Nets, and the logic of delay are not merely decorative parallels. They are structural anchors. Other echoes are supporting atmosphere, suggestive but not load-bearing.
+
+The thesis is strongest when it makes that hierarchy explicit. Skeptical readers need to know which evidence would damage the argument if it failed, and which evidence merely enriches the pattern after the central structure is already in place.
+
+### 3. The argument risks looking unfalsifiable
+
+A hidden-structure argument can become too elastic if every anomaly is treated as confirmation. Elden Glass should therefore be read against constraints:
+
+- the correspondence should attach to named mechanisms in Duchamp's notes, not just broad themes;
+- the game element should do comparable structural work, not merely share imagery;
+- the mapping should be economical, explaining more than it invents;
+- the system should resist arbitrary substitution by another artwork;
+- contradictions should clarify the apparatus rather than merely excuse weak matches.
+
+This does not make the thesis mathematically falsifiable, but art criticism rarely is. It does make the reading accountable.
+
+### 4. The medium translation needs to stay visible
+
+Duchamp's _Large Glass_ is a static cracked pane with notes; _Elden Ring_ is a playable world. The thesis is most convincing when it does not treat this difference as a problem to minimize, but as the central operation: a two-dimensional delayed apparatus becomes a three-dimensional navigable process.
+
+The game does not merely depict the Glass. It spatializes and temporalizes it. The player moves inside relations that Duchamp could only diagram, suspend, or annotate. That is why interactivity matters to the claim rather than being incidental to it.
+
+### 5. The tone can make skeptical readers defensive
+
+The site's voice is intentionally declarative. That is part of its identity. But skeptical readers may need periodic reassurance that the project is not asking for credulity. It is asking for a particular mode of evaluation: compare explanatory power, specificity, economy, and uniqueness.
+
+The site is at its best when confidence is paired with hospitality: not "you must already see it," but "here is the path by which the claim becomes difficult to dismiss."
+
+## What should change in the main thesis
+
+The Living Thesis should not become a defensive FAQ. Its job is to present the argument. But it would benefit from a short methodological passage near the beginning that clarifies:
+
+- the claim is literal, but evaluated by cumulative structure;
+- not all correspondences are equally load-bearing;
+- absence of public confirmation is not decisive, but neither is every resemblance automatically evidence;
+- the reader should judge the thesis by specificity, economy, and uniqueness.
+
+That kind of addition would answer the recurring criticism without derailing the prose.
+
+## What belongs in Critiques instead
+
+Longer objections belong here, not in the main line of the thesis:
+
+- whether hidden intentionality can ever be established without confirmation;
+- whether the reading is overfit or apophenic;
+- whether Duchamp is the uniquely best source text or one of many possible analogues;
+- how much authorial intent matters if the structure is real but unconfirmed;
+- whether the thesis is art criticism, game criticism, pataphysical practice, or all three.
+
+Those are not side issues. They are the conditions under which the central claim can be read fairly.
+
+## Bottom line
+
+The most valuable criticism is not that Elden Glass is too strange. It is that the site must make its own standard of proof unmistakable. A reader can accept that the claim is literal while still needing to know how the site disciplines literalness, how it ranks evidence, and how it prevents interpretation from becoming infinitely permissive.
+
+That is the prose-level work worth doing next.

--- a/content/pages/living-thesis.mdx
+++ b/content/pages/living-thesis.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Living Thesis'
 summary: "The current, evolving statement of the discovery that Elden Ring is Marcel Duchamp's The Large Glass. Where the claim from the initial thesis has been expanded, cited, and pressure-tested."
-updated: '2026-04-11'
+updated: '2026-05-01'
 eyebrow: 'The Living Thesis'
 subtitle: 'The current, evolving statement of the discovery. Where the claim from the initial thesis has been expanded, cited, and pressure-tested.'
 readingMinutes: 45
@@ -29,6 +29,8 @@ This is that.
 What follows is the argument in the order it wants to be read. I begin with the philosophical framework that makes the discovery possible, because without it the secret cannot be recognized as a secret. Then _The Large Glass_ and the preliminary works Duchamp spent a decade building up to it. Then a section on the readymades, which are the methodological template for everything that comes after. Then Elden Ring, then the personal story of how I came to find it, and then the correspondences themselves, followed by the deeper systems the game turns out to be built on.
 
 Any single correspondence can be dismissed as pattern-matching. It is the weight of them, and the precision, that carries the case.
+
+The correspondences should be judged cumulatively, but not indiscriminately. A surface resemblance is not enough. The strongest matches are the ones keyed to named mechanisms in Duchamp's notes and doing comparable structural work inside the game: Bride and Bachelors, Chocolate Grinder, Milky Way, Malic Moulds, Three Nets, delay, glass, and the machinery of frustrated desire. Other echoes can enrich the pattern, but they are not all equally load-bearing. The argument is that the central apparatus explains too much, too specifically, and too economically to be treated as ordinary influence or coincidence.
 
 ---
 

--- a/data/item-cards.json
+++ b/data/item-cards.json
@@ -724,9 +724,9 @@
       "scope": "global",
       "title": "Elden Ring",
       "description": "FromSoftware's 2022 magnum opus. An open-world action RPG created by Hidetaka Miyazaki with worldbuilding by George R.R. Martin.\n\nSites of Grace = Connection points in the apparatus",
-      "section": null,
-      "category": null,
-      "subcategory": null,
+      "section": "Root Concepts",
+      "category": "Source Worlds",
+      "subcategory": "Video Game Cosmology",
       "source": null,
       "image": null,
       "images": [],
@@ -778,9 +778,9 @@
       "scope": "global",
       "title": "Marcel Duchamp",
       "description": "1887-1968. French-American artist who abandoned \"retinal art\" for conceptual work. Chess player. Provocateur. The most influential artist of the 20th century.",
-      "section": null,
-      "category": null,
-      "subcategory": null,
+      "section": "Root Concepts",
+      "category": "Artists and Authors",
+      "subcategory": "Marcel Duchamp",
       "source": null,
       "image": null,
       "images": [],
@@ -840,9 +840,9 @@
       "scope": "global",
       "title": "The Discovery",
       "description": "The Erdtree IS the Bride. The Tarnished ARE the Bachelors. The entire cosmology of the Lands Between maps onto Duchamp's apparatus.\n\nFollow links. The evidence emerges from connections.",
-      "section": null,
-      "category": null,
-      "subcategory": null,
+      "section": "Root Concepts",
+      "category": "Interpretive Thesis",
+      "subcategory": "Elden Ring and The Large Glass",
       "source": null,
       "image": null,
       "images": [],
@@ -903,10 +903,10 @@
       "term": "the green box",
       "scope": "global",
       "title": "The Green Box",
-      "description": null,
-      "section": null,
-      "category": null,
-      "subcategory": null,
+      "description": "Duchamp's 1934 facsimile collection of notes, diagrams, calculations, and verbal fragments for The Bride Stripped Bare by Her Bachelors, Even. The Green Box is not merely documentation for The Large Glass: it is a parallel textual apparatus that Duchamp asked viewers to consult alongside the glass, making reading, cross-reference, and delayed interpretation part of the work itself.",
+      "section": "Marcel Duchamp",
+      "category": "Primary Texts",
+      "subcategory": "Notes and Boxes",
       "source": null,
       "image": "/images/duchamp-notes/green-box/note1.jpg",
       "images": [],
@@ -958,9 +958,9 @@
       "scope": "global",
       "title": "The Large Glass",
       "description": "Marcel Duchamp's The Bride Stripped Bare by Her Bachelors, Even (1915 to 1923) is a unique image text system in which the physical object is complemented by hundreds of preparatory notes the artist considered to be as important as the object itself. The work depicts a mechanical erotic apparatus: the Bride's 'blossoming' above, the Bachelors' futile machinery below. Gas flows, gears turn, desire circulates, but the two realms never truly connect.",
-      "section": null,
-      "category": null,
-      "subcategory": null,
+      "section": "Root Concepts",
+      "category": "Primary Works",
+      "subcategory": "The Large Glass",
       "source": null,
       "image": "/images/duchamp/paintings/the-bride-stripped-bare-by-her-bachelors-1923.jpg",
       "images": [],
@@ -51953,7 +51953,7 @@
     },
     {
       "id": "258e2f4df919b",
-      "term": "prattling pate ",
+      "term": "prattling pate apologies",
       "scope": "global",
       "title": "Prattling Pate \"Apologies\"",
       "description": "Emits a voice that says \"Apologies\"",
@@ -51982,7 +51982,7 @@
     },
     {
       "id": "e581594576455",
-      "term": "prattling pate ",
+      "term": "prattling pate hello",
       "scope": "global",
       "title": "Prattling Pate \"Hello\"",
       "description": "Emits a voice that says \"Hello\"",
@@ -52013,7 +52013,7 @@
     },
     {
       "id": "e1369b7dbbe62",
-      "term": "prattling pate ",
+      "term": "prattling pate lets get to it",
       "scope": "global",
       "title": "Prattling Pate \"Let's get to it\"",
       "description": "Emits a voice that says \"Let's get to it\"",
@@ -52046,7 +52046,7 @@
     },
     {
       "id": "e4fb477f4fdec",
-      "term": "prattling pate ",
+      "term": "prattling pate my beloved",
       "scope": "global",
       "title": "Prattling Pate \"My beloved\"",
       "description": "Emits a voice that says \"My beloved\"",
@@ -52077,7 +52077,7 @@
     },
     {
       "id": "839c5d0ca307a",
-      "term": "prattling pate ",
+      "term": "prattling pate please help",
       "scope": "global",
       "title": "Prattling Pate \"Please help\"",
       "description": "Emits a voice that says \"Please help\"",
@@ -52110,7 +52110,7 @@
     },
     {
       "id": "0cd5f6d765be6",
-      "term": "prattling pate ",
+      "term": "prattling pate thank you",
       "scope": "global",
       "title": "Prattling Pate \"Thank you\"",
       "description": "Emits a voice that says \"Thank you\"",
@@ -52141,7 +52141,7 @@
     },
     {
       "id": "2fbc1141ebfa7",
-      "term": "prattling pate ",
+      "term": "prattling pate wonderful",
       "scope": "global",
       "title": "Prattling Pate \"Wonderful\"",
       "description": "Emits a voice that says \"Wonderful\"",
@@ -52172,7 +52172,7 @@
     },
     {
       "id": "15fa9c6d26d48",
-      "term": "prattling pate ",
+      "term": "prattling pate youre beautiful",
       "scope": "global",
       "title": "Prattling Pate \"You're beautiful\"",
       "description": "Emits a voice that says \"You're beautiful\"",
@@ -112760,7 +112760,7 @@
     },
     {
       "id": "ba6a1ef4ca118",
-      "term": "prattling pate ",
+      "term": "prattling pate lamentation",
       "scope": "global",
       "title": "Prattling Pate \"Lamentation\"",
       "description": "Emits a blissful lamentation",
@@ -126831,10 +126831,10 @@
     },
     {
       "id": "01bf4fbe77353",
-      "term": "boxing match",
+      "term": "boxing match component",
       "scope": "global",
-      "title": "Boxing Match",
-      "description": "Component 14 of The Large Glass",
+      "title": "Boxing Match (Large Glass Component)",
+      "description": "Component 14 of The Large Glass. The Boxing Match is part of the lower bachelor apparatus, a mechanical episode in which desire is staged as impact, contest, and futile transmission rather than consummation.",
       "section": "Marcel Duchamp",
       "category": "The Large Glass",
       "subcategory": "Components",
@@ -126866,10 +126866,10 @@
     },
     {
       "id": "7c96fc00cf904",
-      "term": "capillary tubes",
+      "term": "capillary tubes component",
       "scope": "global",
-      "title": "Capillary Tubes",
-      "description": "Component 3 of The Large Glass",
+      "title": "Capillary Tubes (Large Glass Component)",
+      "description": "Component 3 of The Large Glass. These curved conduits carry bachelor gas away from the malic moulds, translating desire into a routed flow whose shape derives from Duchamp's chance-generated Three Standard Stoppages.",
       "section": "Marcel Duchamp",
       "category": "The Large Glass",
       "subcategory": "Components",
@@ -126911,7 +126911,7 @@
       "term": "sleigh",
       "scope": "global",
       "title": "Chariot/Sleigh",
-      "description": "Component 1 of The Large Glass",
+      "description": "Component 1 of The Large Glass. The Chariot or Sleigh belongs to the bachelor domain as a vehicle of mechanical desire, suggesting motion and transport inside an apparatus that never actually bridges the bride and bachelors.",
       "section": "Marcel Duchamp",
       "category": "The Large Glass",
       "subcategory": "Components",
@@ -126944,7 +126944,7 @@
       "term": "chocolate grinder",
       "scope": "global",
       "title": "Chocolate Grinder",
-      "description": "Component 4 of The Large Glass",
+      "description": "Component 4 of The Large Glass. The Chocolate Grinder is Duchamp's emblem of repetitive bachelor labor: three rollers turning in a closed circuit, producing erotic-machinic energy without reaching the Bride.",
       "section": "Marcel Duchamp",
       "category": "The Large Glass",
       "subcategory": "Components",
@@ -126984,7 +126984,7 @@
       "term": "chocolate grinder no. 1",
       "scope": "global",
       "title": "Chocolate Grinder (No. 1)",
-      "description": "1913, oil and pencil on canvas",
+      "description": "1913, oil and pencil on canvas. The first Chocolate Grinder painting isolates the grinder as a quasi-industrial bachelor machine, establishing the diagrammatic motif Duchamp later folded into The Large Glass.",
       "section": "Marcel Duchamp",
       "category": "The Large Glass",
       "subcategory": "Preparatory Works for The Large Glass",
@@ -127028,7 +127028,7 @@
       "term": "chocolate grinder no. 2",
       "scope": "global",
       "title": "Chocolate Grinder (No. 2)",
-      "description": "1914",
+      "description": "1914. The second Chocolate Grinder refines the motif into a more precise mechanical image, emphasizing the disciplined rotation, measured perspective, and erotic futility that would become central to The Large Glass.",
       "section": "Marcel Duchamp",
       "category": "The Large Glass",
       "subcategory": "Preparatory Works for The Large Glass",
@@ -127066,7 +127066,7 @@
       "term": "splashes",
       "scope": "global",
       "title": "Cradle or Splashes",
-      "description": "Component 12 of The Large Glass",
+      "description": "Component 12 of The Large Glass. The Cradle or Splashes registers the unstable residue of the bachelor mechanism, where projected desire becomes scattered mark, splash, or trace within the lower apparatus.",
       "section": "Marcel Duchamp",
       "category": "The Large Glass",
       "subcategory": "Components",
@@ -127097,7 +127097,7 @@
       "term": "desire gears",
       "scope": "global",
       "title": "Desire gears",
-      "description": "Component 8 of The Large Glass",
+      "description": "Component 8 of The Large Glass. The Desire Gears figure erotic longing as transmission: a set of mechanical relays that convert bachelor desire into motion while keeping it trapped within the lower machine.",
       "section": "Marcel Duchamp",
       "category": "The Large Glass",
       "subcategory": "Components",
@@ -127130,7 +127130,7 @@
       "term": "draught piston",
       "scope": "global",
       "title": "Draught Piston",
-      "description": "Component 9 of The Large Glass",
+      "description": "Component 9 of The Large Glass. The Draught Piston uses chance-shaped forms to mediate between airflow, measurement, and desire, turning atmospheric contingency into a structural part of the glass.",
       "section": "Marcel Duchamp",
       "category": "The Large Glass",
       "subcategory": "Components",
@@ -127202,7 +127202,7 @@
       "term": "king and queen surrounded by swift nudes",
       "scope": "global",
       "title": "King and Queen Surrounded by Swift Nudes",
-      "description": "1912",
+      "description": "1912. King and Queen Surrounded by Swift Nudes belongs to Duchamp's transition through Cubism toward the mechanomorphic vocabulary of The Large Glass, where bodies become trajectories, delays, and apparatuses.",
       "section": "Marcel Duchamp",
       "category": "The Large Glass",
       "subcategory": "Preparatory Works for The Large Glass",
@@ -127332,7 +127332,7 @@
       "term": "nine malic moulds",
       "scope": "global",
       "title": "Nine Malic Moulds/Cemetery of Uniforms and Liveries",
-      "description": "Component 2 of The Large Glass",
+      "description": "Component 2 of The Large Glass. The Nine Malic Moulds, also called the Cemetery of Uniforms and Liveries, are the bachelor identities: standardized occupational shells that generate gas but remain socially and erotically constrained.",
       "section": "Marcel Duchamp",
       "category": "The Large Glass",
       "subcategory": "Components",
@@ -127442,7 +127442,7 @@
       "term": "nine shots",
       "scope": "global",
       "title": "Nine Shots",
-      "description": "Component 17 of The Large Glass",
+      "description": "Component 17 of The Large Glass. The Nine Shots mark the chance-targeted points in the Bride's domain, produced by Duchamp's playful ballistic procedure and later fixed as a diagram of deferred contact.",
       "section": "Marcel Duchamp",
       "category": "The Large Glass",
       "subcategory": "Components",
@@ -127472,10 +127472,10 @@
     },
     {
       "id": "62ed18b9bf418",
-      "term": "nude descending a staircase",
+      "term": "nude descending a staircase large glass context",
       "scope": "global",
-      "title": "Nude Descending a Staircase, No. 2",
-      "description": "1912, Philadelphia Museum of Art",
+      "title": "Nude Descending a Staircase, No. 2 (Large Glass Context)",
+      "description": "1912, Philadelphia Museum of Art. This card tracks Nude Descending a Staircase as a preparatory context for The Large Glass: a figure converted into serial motion, delay, and diagram before Duchamp abandons conventional painting.",
       "section": "Marcel Duchamp",
       "category": "The Large Glass",
       "subcategory": "Preparatory Works for The Large Glass",
@@ -127519,7 +127519,7 @@
       "term": "oculist witnesses",
       "scope": "global",
       "title": "Oculist Witnesses",
-      "description": "Component 13 of The Large Glass",
+      "description": "Component 13 of The Large Glass. The Oculist Witnesses introduce optical testing and perspectival verification into the bachelor apparatus, making vision itself part of the work's machinery of desire and delay.",
       "section": "Marcel Duchamp",
       "category": "The Large Glass",
       "subcategory": "Components",
@@ -127621,10 +127621,10 @@
     },
     {
       "id": "68fd62a81272",
-      "term": "butterfly pump",
+      "term": "butterfly pump component",
       "scope": "global",
       "title": "Region of Butterfly Pump",
-      "description": "Component 10 of The Large Glass",
+      "description": "Component 10 of The Large Glass. The Region of the Butterfly Pump is a propulsive zone in the bachelor mechanism, translating fluttering motion into the circulation of spangles, gas, and erotic energy.",
       "section": "Marcel Duchamp",
       "category": "The Large Glass",
       "subcategory": "Components",
@@ -127844,7 +127844,7 @@
       "term": "sex cylinder",
       "scope": "global",
       "title": "Sex cylinder",
-      "description": "Component 7 of The Large Glass",
+      "description": "Component 7 of The Large Glass. The Sex Cylinder belongs to the bachelor machinery as a bluntly mechanical sign for erotic function, replacing organic union with an abstract rotating part.",
       "section": "Marcel Duchamp",
       "category": "The Large Glass",
       "subcategory": "Components",
@@ -127876,10 +127876,10 @@
     },
     {
       "id": "f61eb4a3c81bc",
-      "term": "sieves",
+      "term": "sieves component",
       "scope": "global",
       "title": "Sieves",
-      "description": "Component 5 of The Large Glass",
+      "description": "Component 5 of The Large Glass. The Sieves filter and process bachelor gas, converting desire into a staged sequence of passage, delay, and refinement before it can move through the apparatus.",
       "section": "Marcel Duchamp",
       "category": "The Large Glass",
       "subcategory": "Components",
@@ -128044,7 +128044,7 @@
       "term": "tender of gravity",
       "scope": "global",
       "title": "Tender of Gravity",
-      "description": "Component 16 of The Large Glass",
+      "description": "Component 16 of The Large Glass. The Tender of Gravity names one of Duchamp's invented mechanical roles, folding physical force, service, and erotic expectation into the lower apparatus.",
       "section": "Marcel Duchamp",
       "category": "The Large Glass",
       "subcategory": "Components",
@@ -128076,10 +128076,10 @@
     },
     {
       "id": "7dd02f98f7e64",
-      "term": "the bride",
+      "term": "bride mariee study",
       "scope": "global",
-      "title": "The Bride (Mariée)",
-      "description": "1912",
+      "title": "The Bride (Mariée Study)",
+      "description": "1912. The Bride (Mariée) is one of Duchamp's key Munich works, transforming the female figure into a mechanomorphic diagram and preparing the upper Bride domain of The Large Glass.",
       "section": "Marcel Duchamp",
       "category": "The Large Glass",
       "subcategory": "Preparatory Works for The Large Glass",
@@ -128108,10 +128108,10 @@
     },
     {
       "id": "1d20f52214cbf",
-      "term": "the bride",
+      "term": "bride pendu femelle component",
       "scope": "global",
-      "title": "The Bride/Pendu femelle",
-      "description": "Component 6 of The Large Glass",
+      "title": "The Bride/Pendu femelle (Large Glass Component)",
+      "description": "Component 6 of The Large Glass. The Bride or Pendu femelle occupies the upper realm of the apparatus, a suspended mechanomorphic figure whose blossoming motivates the bachelors below while remaining unreachable.",
       "section": "Marcel Duchamp",
       "category": "The Large Glass",
       "subcategory": "Components",
@@ -128150,10 +128150,10 @@
     },
     {
       "id": "324a80534f97e",
-      "term": "passage from virgin to bride",
+      "term": "passage from virgin to bride large glass context",
       "scope": "global",
-      "title": "The Passage from Virgin to Bride",
-      "description": "July-August 1912, MoMA New York",
+      "title": "The Passage from Virgin to Bride (Large Glass Context)",
+      "description": "July-August 1912, MoMA New York. This card tracks The Passage from Virgin to Bride as a preparatory context for The Large Glass, where transformation is treated as a delayed mechanical and erotic transition.",
       "section": "Marcel Duchamp",
       "category": "The Large Glass",
       "subcategory": "Preparatory Works for The Large Glass",
@@ -128197,7 +128197,7 @@
       "term": "slopes of flow",
       "scope": "global",
       "title": "Toboggan or Plastic/Slopes of flow",
-      "description": "Component 11 of The Large Glass",
+      "description": "Component 11 of The Large Glass. The Toboggan or Plastic Slopes of Flow gives bachelor gas a slanted path, turning descent, drift, and controlled slippage into visible parts of the machine.",
       "section": "Marcel Duchamp",
       "category": "The Large Glass",
       "subcategory": "Components",
@@ -129269,7 +129269,7 @@
     },
     {
       "id": "nude-descending-a-staircase",
-      "term": "nude descending a staircase",
+      "term": "nude descending a staircase painting",
       "scope": "global",
       "title": "Nude Descending a Staircase, No. 2",
       "description": "1912. Philadelphia Museum of Art. \"A painting that helped to introduce Modern Art to New York with a bang in 1913.\" Duchamp's last \"clear attempt to use a traditional modality of retinal art to express a conceptual or gray matter art.\" When asked if the nude was male or female, Duchamp replied: \"Is it a woman? No. Is it a man? No. To tell you the truth, I have never thought which it is.\" — Tout-Fait",
@@ -129389,7 +129389,7 @@
     },
     {
       "id": "passage-from-virgin-to-bride",
-      "term": "passage from virgin to bride",
+      "term": "passage from virgin to bride painting",
       "scope": "global",
       "title": "The Passage from Virgin to Bride",
       "description": "1912. Painted in Munich alongside The Bride. One of the key works from Duchamp's Munich period where he \"discovered the theme of his Grand Oeuvre\" and produced related works including Virgin (No. 1), Virgin (No. 2), and Mécanique de la Pudeur. — Tout-Fait",
@@ -130165,7 +130165,7 @@
     },
     {
       "id": "capillary-tubes",
-      "term": "capillary tubes",
+      "term": "capillary tubes animation",
       "scope": "global",
       "title": "The Capillary Tubes",
       "description": "\"The bachelor gas flows out of the molds into conduits called the Capillary Tubes. The malic gas begins to liquefy. Toward the end of the tubes 'the gas takes on a liquid elemental state'.\" Animation by Andrew Stafford. — understandingduchamp.com",
@@ -130216,7 +130216,7 @@
     },
     {
       "id": "sieves",
-      "term": "sieves",
+      "term": "sieves animation",
       "scope": "global",
       "title": "The Sieves",
       "description": "\"The gas is captured by a series of Sieves. The Sieves are cone-shaped. They're propelled through the Sieves by a device called the Butterfly Pump. Inside the sieves, the gas is 'dazed'. The butterfly 'drives the spangles of the liquified gas towards a drying pump'.\" Animation by Andrew Stafford. — understandingduchamp.com",
@@ -130273,7 +130273,7 @@
     },
     {
       "id": "butterfly-pump",
-      "term": "butterfly pump",
+      "term": "butterfly pump animation",
       "scope": "global",
       "title": "The Butterfly Pump",
       "description": "\"The Butterfly Pump is a propelling mechanism. The butterfly 'drives the spangles of the liquified gas towards a drying pump.' The form may have been inspired by the suction pumps on petrol cans of Duchamp's era.\" Animation by Andrew Stafford. — understandingduchamp.com",
@@ -130438,7 +130438,7 @@
     },
     {
       "id": "boxing-match",
-      "term": "boxing match",
+      "term": "boxing match animation",
       "scope": "global",
       "title": "The Boxing Match",
       "description": "\"The Boxing Match is a mechanism within the Fate Machine. It features 'combat marble' rams that strike each other. The mechanism runs on a clockwork spring, 'the fall of the mobile weights'. The Boxing Match introduces an element of controlled violence into the operation of fate.\" Animation by Andrew Stafford. — understandingduchamp.com",
@@ -131578,9 +131578,9 @@
     },
     {
       "id": "pata-capillary-tubes",
-      "term": "capillary tubes",
+      "term": "capillary tubes pataphysical reading",
       "scope": "global",
-      "title": "Capillary Tubes",
+      "title": "Capillary Tubes ('Pataphysical Reading)",
       "description": "In The Large Glass, the curved forms derived from the Three Standard Stoppages templates. The illuminating gas from the Malic Moulds travels through these tubes after passing through the Sieves. The chance generated curves of the dropped strings become the pathways for desire's transformation, connecting the random to the systematic.",
       "section": "'Pataphysics",
       "category": "'Pataphysics Vocabulary",
@@ -131646,9 +131646,9 @@
     },
     {
       "id": "pata-clinamen",
-      "term": "clinamen",
+      "term": "clinamen core law",
       "scope": "global",
-      "title": "Clinamen",
+      "title": "Clinamen (Core Pataphysical Law)",
       "description": "One of the Two Laws of Pataphysics. From Lucretius's De rerum natura: 'so that the mind itself may not be subject / To inner necessity in what it does— / And fetch and carry like a captive slave— / The tiny swerve of atoms plays its part / At unanticipated times and places.' For Lucretius, 'atoms are to matter what letters are to words.' The clinamen 'marks an atom's deviation from its path, its aberration from a stable flow, and its consequent collision with other atoms to produce a new material formation.' The key insight: 'Whereas science would work to suppress any deviance from its own regulatory laws... pataphysics seeks their proliferation and operates at the very moment and place where the law is insufficient to prevent the clinamen.' Compare to the Golden Order's Law of Causality—which enforces determinism, cause preceding effect. Clinamen is the escape from Causality, the tiny swerve that frees the mind from inner necessity. Where Causality binds, Clinamen liberates. Every ending that breaks the cycle is a clinamen.",
       "section": "'Pataphysics",
       "category": "Core Pataphysical Terms",
@@ -131690,9 +131690,9 @@
     },
     {
       "id": "pata-syzygy",
-      "term": "syzygy",
+      "term": "syzygy core law",
       "scope": "global",
-      "title": "Syzygy",
+      "title": "Syzygy (Core Pataphysical Law)",
       "description": "One of the Two Laws of Pataphysics. 'In its astronomical use, syzygy refers to a conjunction or opposition of the systems of two planets in their orbit around a third; in its biological deployment the term denotes the conjunction of two organisms without the loss of identity.' Crucially: conjunction WITHOUT loss of identity. 'Syzygies make manifest those momentary oppositions and conjunctions in verbal meanings (as puns and portmanteaux, such as Jarry's famous semantic conjunction of space and time, ether and eternity in the word \"ethernity\").' Compare to the Golden Order's Law of Regression—which forces all things to converge back to their source, absorbing difference into unity. Syzygy allows conjunction while preserving difference; Regression demands convergence that erases it. Radagon and Marika ARE a true syzygy—two beings conjoined who RETAIN their opposing identities, orbiting the Elden Ring in eternal opposition. Marika shatters; Radagon repairs. Neither will absorbs the other. The discovery that Elden Ring corresponds to The Large Glass is a true syzygy: conjunction across a century without either work losing its identity.",
       "section": "'Pataphysics",
       "category": "Core Pataphysical Terms",
@@ -131770,9 +131770,9 @@
     },
     {
       "id": "pata-ethernity",
-      "term": "ethernity",
+      "term": "ethernity jarryan realm",
       "scope": "global",
-      "title": "Ethernity",
+      "title": "Ethernity (Jarryan Realm)",
       "description": "Not eternity—ethernity. Jarry's invented realm, the space Dr. Faustroll enters after 'making the gesture of dying.' A place outside time and space entirely. Farum Azula exists in ethernity—frozen outside the normal flow of time, waiting at the junction between worlds. Ranni's thousand-year voyage occurs in ethernity. The Roundtable Hold, accessible only through grace, floats in ethernity. These are not places in the world but places supplementary to it.",
       "section": "'Pataphysics",
       "category": "Core Pataphysical Terms",
@@ -131838,9 +131838,9 @@
     },
     {
       "id": "pata-livres-pairs",
-      "term": "livres pairs",
+      "term": "livres pairs equivalent books",
       "scope": "global",
-      "title": "Livres Pairs",
+      "title": "Livres Pairs (Equivalent Books)",
       "description": "Equivalent books. Jarry's notion that different works can be structurally equivalent while asserting simultaneously that similar things are not identical (A ≠ A). Dr. Faustroll's library contains twenty-seven 'equivalent books' that together compose a complete picture of his intellectual world. The Soulsborne games are livres pairs—Dark Souls, Bloodborne, Sekiro, Elden Ring are equivalent but not identical, each a different angle on the same underlying structure. The Large Glass and Elden Ring are livres pairs across media and centuries.",
       "section": "'Pataphysics",
       "category": "Core Pataphysical Terms",
@@ -131874,9 +131874,9 @@
     },
     {
       "id": "pata-dr-faustroll",
-      "term": "Faustroll",
+      "term": "dr faustroll pataphysical figure",
       "scope": "global",
-      "title": "Dr. Faustroll",
+      "title": "Dr. Faustroll (Pataphysical Figure)",
       "description": "The pataphysician. Hero of Jarry's 1911 novel. His name contains three puns: 'Faust troll,' 'Faust role,' and 'Faust roll' (scroll). Born at age sixty-three when 'the 20th century was -2 years old.' Claims 'I am God' and offers a geometric proof. After 'making the gesture of dying,' his body unrolls like wallpaper to reveal that 'all art and all science were written in the curves of his limbs.' Jarry identified himself with Faustroll, not Ubu. Faustroll is the model for the player character: arriving fully formed, navigating a world of equivalent islands, accumulating knowledge that will only make sense when unrolled at the end.",
       "section": "'Pataphysics",
       "category": "Pataphysical Figures",
@@ -131914,9 +131914,9 @@
     },
     {
       "id": "pata-bosse-de-nage",
-      "term": "Bosse-de-Nage",
+      "term": "bosse de nage faustroll figure",
       "scope": "global",
-      "title": "Bosse-de-Nage",
+      "title": "Bosse-de-Nage (Faustroll Figure)",
       "description": "The hydrocephalic, dog-faced baboon who serves as Dr. Faustroll's cabin boy. His only utterance is 'Ha ha.' Later strangled by Faustroll and resurrected through 'subfumigation.' The name means 'swimming hump.' His 'Ha ha' is not laughter but a complete philosophical statement, explored in a chapter titled 'Concerning Some Further and More Evident Meanings of the Words Ha Ha.' The spirit summons in Elden Ring who appear, fight, and vanish with minimal communication are Bosse-de-Nages—companions whose contribution is presence and action, not explanation.",
       "section": "'Pataphysics",
       "category": "Pataphysical Figures",
@@ -131952,9 +131952,9 @@
     },
     {
       "id": "pata-the-sieve",
-      "term": "sieve",
+      "term": "sieve faustroll vessel",
       "scope": "global",
-      "title": "The Sieve",
+      "title": "The Sieve (Faustroll Vessel)",
       "description": "Dr. Faustroll's twelve-meter copper-mesh skiff that floats on water by surface tension alone. The vessel for his voyage 'from Paris to Paris by sea.' The real challenge of sailing in a sieve is that it requires constant attention to the act of bailing—maintaining 'a precarious balance at the intersection of imminent submersion and pataphysical buoyancy.' This is the condition of playing a FromSoftware game: you are always about to sink, always bailing, always requiring absolute presence to stay afloat. The game is a sieve. The lore is a sieve. You sail or you drown.",
       "section": "'Pataphysics",
       "category": "Pataphysical Objects",
@@ -131988,9 +131988,9 @@
     },
     {
       "id": "pata-gidouille",
-      "term": "gidouille",
+      "term": "gidouille ubu object",
       "scope": "global",
-      "title": "Gidouille",
+      "title": "Gidouille (Ubu Object)",
       "description": "Ubu's belly. A belly so big and singular in appetite that it required the invention of its own term. The spiral on Ubu's stomach, symbol of his insatiable consumption. Often depicted as a spiral—the same shape as the Elden Ring itself, the same shape as the grace that guides the Tarnished, the same shape as the cycle that keeps repeating. The gidouille consumes everything and produces nothing but merdre. The Erdtree is a gidouille—a golden spiral that consumes the dead and produces only more of itself.",
       "section": "'Pataphysics",
       "category": "Pataphysical Objects",
@@ -132055,9 +132055,9 @@
     },
     {
       "id": "pata-jocoserious",
-      "term": "jocoserious",
+      "term": "jocoserious pataphysical concept",
       "scope": "global",
-      "title": "Jocoserious",
+      "title": "Jocoserious (Pataphysical Concept)",
       "description": "Serious humor. Humorous seriousness. The term is usually attributed to Joyce, but Jarry was practicing it decades earlier. The jocoserious is not comedy that undermines seriousness, nor seriousness that tolerates comedy—it is the recognition that the deepest truths can only be approached through laughter. FromSoftware's design is jocoserious: 'Try finger, but hole' exists in the same game as Millicent's tragedy. The memes and the meaning are not separate registers but the same register operating at different frequencies.",
       "section": "'Pataphysics",
       "category": "Pataphysical Concepts",
@@ -132088,9 +132088,9 @@
     },
     {
       "id": "pata-hermeneutic-paranoia",
-      "term": "hermeneutic paranoia",
+      "term": "hermeneutic paranoia reading condition",
       "scope": "global",
-      "title": "Hermeneutic Paranoia",
+      "title": "Hermeneutic Paranoia (Reading Condition)",
       "description": "The condition induced by Jarry's texts: a compulsion to constantly search for hidden signs, symbols, and allusions—'to see signs everywhere, to interpret the smallest aspect of the text, to suspect meaning beneath every particle of the work.' But there is also its opposite: anti-hermeneutic paranoia, the fear that all apparent meaning is just a prank. The lore community lives in both paranoias simultaneously. Everything connects AND nothing means anything. The item descriptions are profound AND they're trolling you. Both are true. This is the correct way to read.",
       "section": "'Pataphysics",
       "category": "Pataphysical Concepts",
@@ -132204,10 +132204,10 @@
     },
     {
       "id": "pata-patadata",
-      "term": "patadata",
+      "term": "patadata computing layer",
       "scope": "global",
-      "title": "Patadata",
-      "description": "A pataphysical intelligence layer built on RDF triples (object, relation, value) where the relation slot can be a pataphysical term. Where normal metadata describes things accurately, patadata embraces what Cory Doctorow called 'metacrap': people lie, people are lazy, schemas aren't neutral, metrics influence results, there's more than one way to describe something. Patadata uses the Panalogy Principle: 'If you understand something in only one way then you scarcely understand it at all... if you represent something in several ways, then when one fails you can switch to another.' The lore community produces patadata constantly—multiple contradictory interpretations of the same item description, each valid from a different angle. The title card system itself is patadata: objects connected by grace relations that express pataphysical correspondences.",
+      "title": "Patadata (Computing Layer)",
+      "description": "A pataphysical intelligence layer built on RDF triples (object, relation, value) where the relation slot can be a pataphysical term. Where normal metadata describes things accurately, patadata embraces what Cory Doctorow called 'metacrap': people lie, people are lazy, schemas aren't neutral, metrics influence results, there's more than one way to describe something. Patadata uses the Panalogy Principle: 'If you understand something in only one way then you scarcely understand it at all... if you represent something in several ways, then when one fails you can switch to another.' The lore community produces patadata constantly—multiple contradictory interpretations of the same item description, each valid from a different angle. The item card system itself is patadata: objects connected by grace relations that express pataphysical correspondences.",
       "section": "'Pataphysics",
       "category": "Pataphysical Computing",
       "links": [],
@@ -132242,9 +132242,9 @@
     },
     {
       "id": "pata-syzygy-surfer",
-      "term": "Syzygy Surfer",
+      "term": "syzygy surfer search engine",
       "scope": "global",
-      "title": "Syzygy Surfer",
+      "title": "Syzygy Surfer (Search Engine)",
       "description": "A pataphysical search engine that doesn't take you where you want to go, but somewhere you didn't expect and are glad you arrived. Unlike random search engines, it produces 'surprising yet charming encounters' through three modes: Syzygy search finds unexpected alignments between terms. Clinamen search transforms definitions into creative deviations. Anomaly search finds occurrences missing common referents—the exceptions. The lore community operates as a collective Syzygy Surfer. Every theory is a search result. Every 'wait, what if...' is a clinamen query. Every 'why doesn't anyone mention...' is an anomaly search. The discovery that Elden Ring corresponds to The Large Glass was itself a syzygy—not looking for Duchamp, finding Duchamp through unexpected alignment, arriving somewhere unexpected and being glad to have arrived.",
       "section": "'Pataphysics",
       "category": "Pataphysical Computing",
@@ -132400,9 +132400,9 @@
     },
     {
       "id": "pata-intraphysics",
-      "term": "intraphysics",
+      "term": "intraphysics rybak concept",
       "scope": "global",
-      "title": "Intraphysics",
+      "title": "Intraphysics (Rybak Concept)",
       "description": "'To take a piece of wood and a piece of iron and find their continuity, and from there seek to transform one into the other, that is intraphysics.' Boris Rybak's science of 'unauthorized equivalence, of reckless analogy.' The intraphysicist 'concerns himself not only with that which is, has been, and will be, but also creates ideas with irrational content that he then dissects; he studies what might have been... the imaged concretization of the unimaginable.' Where physics studies what is, and metaphysics studies what must be, intraphysics studies the impossible continuity between unlike things. Every item description that connects a mundane object to cosmic significance practices intraphysics. The Dectus Medallion is half a piece of metal; it is also the key to the Altus Plateau; it is also a symbol of covenant; it is also a game mechanic. Finding the continuity between these—that is intraphysics.",
       "section": "'Pataphysics",
       "category": "Pataphysical Concepts",
@@ -132600,7 +132600,7 @@
     },
     {
       "id": "pata-oulipo-constraints",
-      "term": "anoulipism",
+      "term": "anoulipism and synthoulipism",
       "scope": "global",
       "title": "Anoulipism & Synthoulipism",
       "description": "The Oulipo—Ouvroir de Littérature Potentielle, 'Workshop of Potential Literature'—founded by François Le Lionnais and Raymond Queneau. Its dual practice: 'to research (anoulipism) and create (synthoulipism) forms and constraints with which literature has been or could be written.' Anoulipism discovers existing constraints; synthoulipism invents new ones. Perec's novel without the letter 'e' is synthoulipism. Finding that sonnets already constrain in particular ways is anoulipism. Miyazaki practices both. Anoulipism: discovering how Duchamp's Large Glass constrains, then working within those constraints. Synthoulipism: inventing the fragmentary lore system, the boss-locked narrative, the death-loop structure. The Oulipo recognized that all literature operates under constraints, visible or invisible—the pataphysician makes the constraints explicit and plays with them deliberately.",
@@ -132940,7 +132940,7 @@
     },
     {
       "id": "pata-neo-scientific-novel",
-      "term": "neo-scientific novel",
+      "term": "neo scientific novel full title",
       "scope": "global",
       "title": "The Neo-Scientific Novel",
       "description": "The full title of Jarry's masterwork: 'Exploits and Opinions of Dr. Faustroll, Pataphysician (A Neo-Scientific Novel).' A genre that presents invented knowledge with the gravity of scientific fact—complete with precise measurements, technical vocabulary, and methodological rigor—while the content is patently absurd. The neo-scientific novel doesn't parody science; it practices science on impossible objects. Faustroll's measurements of God's surface area. The exact specifications of his sieve-boat. The chemical formula for his time machine. Elden Ring is a neo-scientific novel in game form. Item descriptions read like field notes. The game tracks exact damage numbers, scaling coefficients, frame data. The Golden Order has laws, theorems, fundamentals. All of this scientific apparatus applied to a world where a woman can become a tree, where death is a temporary inconvenience, where the moon is a person. Neo-scientific: rigorous method, impossible object.",
@@ -132982,9 +132982,9 @@
     },
     {
       "id": "pata-definitional-literature",
-      "term": "definitional literature",
+      "term": "definitional literature oulipo practice",
       "scope": "global",
-      "title": "Definitional Literature",
+      "title": "Definitional Literature (Oulipo Practice)",
       "description": "A pataphysical writing practice theorized by the Oulipo: 'In a given statement, one replaces each significant word by one of its definitions from a given dictionary; the operation is repeated on the new sentence thus obtained, and so on.' Also called 'semo-definitional literature' or LSD (Littérature Sémo-Définitionnelle). Each word spirals into its definition, which spirals into further definitions, 'production automatique de littérature française.' The goal: revealing that language contains 'its own inner principle of proliferation'—meaning generates meaning generates meaning without end. The lore community practices definitional literature constantly. What is the Erdtree? A tree that is also grace that is also the Greater Will's instrument that is also a prison that is also... Each definition opens into further definitions. What is a Tarnished? The definition never stabilizes. 'One can operate definitional literature in the most mechanical way'—and the wiki does exactly that, mechanically expanding each term into its component definitions.",
       "section": "'Pataphysics",
       "category": "Pataphysical Literature",
@@ -133719,9 +133719,9 @@
     },
     {
       "id": "pata-merdre",
-      "term": "merdre",
+      "term": "merdre ubu opening word",
       "scope": "global",
-      "title": "Merdre!",
+      "title": "Merdre! (Ubu Opening Word)",
       "description": "'The (in)famous neological euphemism that is the first word spoken in Jarry's Ubu Roi: \"Merdre!\"' Shit with an extra letter. The clinamen applied to profanity—a tiny swerve that transforms the expected into the unexpected. When Ubu spoke this word on opening night in 1896, it caused a riot. The audience heard 'merde' (shit) but saw 'merdre'—same but different, obscene but not quite, the familiar made strange by a single letter. This is pataphysics in miniature: the smallest possible deviation creating the maximum possible disruption. The 'r' is a clinamen. It swerves the word from its expected path. Atoms are to matter what letters are to words—and one letter changes everything. Every FromSoftware neologism works this way: 'Tarnished' (tarnish + vanished?), 'Elden' (elder + golden?), 'Erdtree' (earth + tree but German). The clinamen at the level of the letter. Merdre!",
       "section": "'Pataphysics",
       "category": "Core Pataphysical Terms",
@@ -134816,8 +134816,8 @@
     },
     {
       "id": "pata-vocab-b4-syzygy-surfer",
-      "term": "syzygy surfer",
-      "title": "Syzygy Surfer",
+      "term": "syzygy surfer vocabulary entry",
+      "title": "Syzygy Surfer (Vocabulary Entry)",
       "description": "A pataphysical search tool designed to find connections through syzygy, clinamen, and anomaly rather than conventional Boolean search. Seeks unexpected alignments and coincidences across datasets.",
       "section": "Pataphysics",
       "category": "Vocabulary",
@@ -134876,8 +134876,8 @@
     },
     {
       "id": "pata-vocab-b4-patadata",
-      "term": "patadata",
-      "title": "Patadata",
+      "term": "patadata vocabulary entry",
+      "title": "Patadata (Vocabulary Entry)",
       "description": "Data structured according to pataphysical principles, emphasizing the exceptional, the anomalous, and the contradictory rather than the typical or average. Contrasts with conventional metadata focused on standardization.",
       "section": "Pataphysics",
       "category": "Vocabulary",
@@ -136178,8 +136178,8 @@
     },
     {
       "id": "pata-vocab-b2-college-pataphysique",
-      "term": "collège de 'pataphysique",
-      "title": "Collège de 'Pataphysique",
+      "term": "college de pataphysique institution",
+      "title": "Collège de 'Pataphysique (Institution)",
       "description": "Official organization founded to preserve and extend Jarry's pataphysical philosophy. Numerous artists including Asger Jorn and James Brewton were inspired by its official-sounding societies and institutes to create their own pataphysical institutions.",
       "section": "Pataphysics",
       "category": "Vocabulary",
@@ -136277,8 +136277,8 @@
     },
     {
       "id": "pata-vocab-b2-syzygy",
-      "term": "syzygy",
-      "title": "Syzygy",
+      "term": "syzygy astronomical alignment",
+      "title": "Syzygy (Astronomical Alignment)",
       "description": "One of two laws regulating pataphysics. In astronomy, a conjunction or opposition of two planets in orbit around a third. In biology, conjunction of two organisms without loss of identity. In language, momentary oppositions and conjunctions in verbal meanings (puns and portmanteaux).",
       "section": "Pataphysics",
       "category": "Vocabulary",
@@ -136314,8 +136314,8 @@
     },
     {
       "id": "pata-vocab-b2-clinamen",
-      "term": "clinamen",
-      "title": "Clinamen",
+      "term": "clinamen lucretian swerve",
+      "title": "Clinamen (Lucretian Swerve)",
       "description": "From ancient Greek particle physics via Lucretius: the swerve or deviation of an atom from its path, causing collision with other atoms to produce new formations. In pataphysics and poetry, the clinamen marks deviation from stable flow, the moment where law is insufficient to prevent aberration.",
       "section": "Pataphysics",
       "category": "Vocabulary",
@@ -136351,8 +136351,8 @@
     },
     {
       "id": "pata-vocab-b2-ethernity",
-      "term": "ethernity",
-      "title": "Ethernity",
+      "term": "ethernity portmanteau",
+      "title": "Ethernity (Ether/Eternity Portmanteau)",
       "description": "Jarry's portmanteau word fusing ether and eternity, anticipating Einstein's fusion of space and time. Describes immobile ether that is not luminiferous, contrasting with perishable, circularly mobile luminiferous ether.",
       "section": "Pataphysics",
       "category": "Vocabulary",
@@ -137146,8 +137146,8 @@
     },
     {
       "id": "pata-vocab-b2-oulipo",
-      "term": "oulipo",
-      "title": "Oulipo",
+      "term": "oulipo constraint movement",
+      "title": "Oulipo (Constraint Movement)",
       "description": "Literary movement known for voluntary submission to linguistic constraints including palindromes, acrostics, lipograms, rhopalics, and homophonic translations. An offshoot of the Collège de 'Pataphysique.",
       "section": "Pataphysics",
       "category": "Vocabulary",
@@ -137278,8 +137278,8 @@
     },
     {
       "id": "pata-vocab-b1-jocoserious",
-      "term": "jocoserious",
-      "title": "Jocoserious",
+      "term": "jocoserious vocabulary entry",
+      "title": "Jocoserious (Vocabulary Entry)",
       "description": "A term coined by Joyce describing art that combines humor and seriousness. Jarry's pataphysics embodies this quality decades before Joyce named it. Duchamp called for art with humor that added a note of seriousness. The deeply serious humor at the substance of pataphysics.",
       "section": "Pataphysics",
       "category": "Vocabulary",
@@ -137307,8 +137307,8 @@
     },
     {
       "id": "pata-vocab-b1-neo-scientific-novel",
-      "term": "neo-scientific novel",
-      "title": "Neo-Scientific Novel",
+      "term": "neo scientific novel vocabulary entry",
+      "title": "Neo-Scientific Novel (Vocabulary Entry)",
       "description": "Jarry's designation for Exploits and Opinions of Dr. Faustroll, Pataphysician. A novel form that blurs the lines between fiction and nonfiction, literature and science, nonsense and philosophy. It situates science in the realm of the imaginary and speculative while making use of actual scientific and mathematical theories.",
       "section": "Pataphysics",
       "category": "Vocabulary",
@@ -137334,8 +137334,8 @@
     },
     {
       "id": "pata-vocab-b1-dr-faustroll",
-      "term": "dr. faustroll",
-      "title": "Dr. Faustroll",
+      "term": "dr faustroll vocabulary entry",
+      "title": "Dr. Faustroll (Vocabulary Entry)",
       "description": "The protagonist of Jarry's Exploits and Opinions of Dr. Faustroll, Pataphysician. An ultrasexagenarian ephebe who travels from Paris to Paris by sieve. The Inamovable Curator of the Collège de 'Pataphysique. More than a character representing Jarry, Faustroll embodies an artistic-scientific energy, a continually unrolling force that creates and reveals alternative realities.",
       "section": "Pataphysics",
       "category": "Vocabulary",
@@ -137394,8 +137394,8 @@
     },
     {
       "id": "pata-vocab-b1-merdre",
-      "term": "merdre",
-      "title": "Merdre",
+      "term": "merdre vocabulary entry",
+      "title": "Merdre (Vocabulary Entry)",
       "description": "The French word for 'shit' with an extra 'r', the first word of Ubu Roi that caused a riot. A thinly veiled expletive that symbolically threw excrement at the audience, eliciting both outraged protests and uproarious laughter. Ubu's signature robotic repetition reveals him as the embodiment of Bergsonian comedy—laughable as he reminds us of a mere machine.",
       "section": "Pataphysics",
       "category": "Vocabulary",
@@ -137499,8 +137499,8 @@
     },
     {
       "id": "pata-vocab-b1-livres-pairs",
-      "term": "livres pairs",
-      "title": "Livres Pairs",
+      "term": "livres pairs vocabulary entry",
+      "title": "Livres Pairs (Vocabulary Entry)",
       "description": "Equivalent books. Jarry often played with notions of equivalence and difference, asserting simultaneously that books could be equivalent and that, when examined closely, things that appear similar are not (A ≠ A).",
       "section": "Pataphysics",
       "category": "Vocabulary",
@@ -137532,8 +137532,8 @@
     },
     {
       "id": "pata-vocab-b1-ethernity",
-      "term": "ethernity",
-      "title": "Ethernity",
+      "term": "ethernity outside time and space",
+      "title": "Ethernity (Outside Time and Space)",
       "description": "A truly pataphysical realm completely outside of time and space. In book 7 of Faustroll, the protagonist sinks his sieve and drowns himself, making 'the gesture of dying' and is translated to ethernity. From ethernity, Faustroll offers a geometrical proof of God's existence leading to the solution '8 = 0'.",
       "section": "Pataphysics",
       "category": "Vocabulary",
@@ -137598,8 +137598,8 @@
     },
     {
       "id": "pata-vocab-b1-bosse-de-nage",
-      "term": "bosse-de-nage",
-      "title": "Bosse-de-Nage",
+      "term": "bosse de nage vocabulary entry",
+      "title": "Bosse-de-Nage (Vocabulary Entry)",
       "description": "Dr. Faustroll's cabin boy, a hydrocephalic dog-faced baboon capable of only one utterance: 'Ha ha.' Bosse-de-Nage personifies the instinctual reaction that, together with Panmuphle's intellectual seriousness, represents mutually exclusive opposites that Faustroll (and Jarry) insist can coexist. In pataphysical logic: 1 + 1 = 3.",
       "section": "Pataphysics",
       "category": "Vocabulary",
@@ -137666,8 +137666,8 @@
     },
     {
       "id": "pata-vocab-b1-sieve-vessel",
-      "term": "sieve",
-      "title": "Sieve (Vessel)",
+      "term": "sieve vessel vocabulary entry",
+      "title": "Sieve (Vessel Vocabulary Entry)",
       "description": "Dr. Faustroll's vessel for his voyage from Paris to Paris: a twelve-meter-long copper-mesh skiff that floats on water by surface tension. The real challenge of setting sail in a sieve is keeping water from seeping in—it requires constant attention to bailing out the boat to maintain precarious balance at the intersection of imminent submersion and pataphysical buoyancy.",
       "section": "Pataphysics",
       "category": "Vocabulary",
@@ -137705,8 +137705,8 @@
     },
     {
       "id": "pata-vocab-b1-clinamen",
-      "term": "clinamen",
-      "title": "Clinamen",
+      "term": "clinamen college usage",
+      "title": "Clinamen (Collège Usage)",
       "description": "One of the Collège de 'Pataphysique's idiosyncratic concepts with uniquely pataphysical connotations. The smallest possible aberration or swerve. A term borrowed from Lucretius referring to the unpredictable swerve of atoms that allows for free will and spontaneous variation in an otherwise deterministic universe.",
       "section": "Pataphysics",
       "category": "Vocabulary",
@@ -137732,7 +137732,7 @@
     },
     {
       "id": "pata-vocab-b1-syzygy-pata",
-      "term": "syzygy",
+      "term": "syzygy pataphysical alignment",
       "title": "Syzygy (Pataphysical)",
       "description": "One of the Collège's idiosyncratic concepts. In astronomy, the alignment of three celestial bodies. In pataphysics, it represents moments of conjunction where opposites meet without canceling each other out. The Collège uses this term with uniquely pataphysical connotations.",
       "section": "Pataphysics",
@@ -137823,8 +137823,8 @@
     },
     {
       "id": "pata-vocab-b1-college-de-pataphysique",
-      "term": "collège de 'pataphysique",
-      "title": "Collège de 'Pataphysics",
+      "term": "college de pataphysics vocabulary entry",
+      "title": "Collège de 'Pataphysics (Vocabulary Entry)",
       "description": "A parodically formal collective formed in Paris in 1948 to explore 'the science.' With Dr. Faustroll as Inamovable Curator, Marcel Duchamp as Grand Satrap, and members including Boris Vian, Max Ernst, Raymond Queneau, Man Ray, Jean Dubuffet, Groucho Marx, and Eugène Ionesco. An intentional contradiction in terms: a 'pataphysical institution.'",
       "section": "Pataphysics",
       "category": "Vocabulary",
@@ -137858,8 +137858,8 @@
     },
     {
       "id": "pata-vocab-b1-oulipo",
-      "term": "oulipo",
-      "title": "Oulipo",
+      "term": "oulipo college subcommittee",
+      "title": "Oulipo (Collège Subcommittee)",
       "description": "Ouvroir de Littérature Potentielle—Workshop of Potential Literature. A subcommittee of the Collège de 'Pataphysique founded in 1960 by François Le Lionnais and Raymond Queneau. Consists of mathematicians and writers researching and creating forms and constraints with which literature has been or could be written.",
       "section": "Pataphysics",
       "category": "Vocabulary",
@@ -137885,8 +137885,8 @@
     },
     {
       "id": "pata-vocab-b1-anoulipism",
-      "term": "anoulipism",
-      "title": "Anoulipism",
+      "term": "anoulipism vocabulary entry",
+      "title": "Anoulipism (Vocabulary Entry)",
       "description": "The Oulipo's term for research into forms and constraints that have already been used in literature. The analytical side of Oulipian practice, studying what has been done. Complements synthoulipism, which creates new forms.",
       "section": "Pataphysics",
       "category": "Vocabulary",
@@ -138128,8 +138128,8 @@
     },
     {
       "id": "pata-vocab-b1-definitional-literature",
-      "term": "definitional literature",
-      "title": "Definitional Literature",
+      "term": "definitional literature vocabulary entry",
+      "title": "Definitional Literature (Vocabulary Entry)",
       "description": "A technique pioneered by Stefan Themerson and developed by the Oulipo, with experiments by Georges Perec and Marcel Bénabou. Literature that uses definitions as its primary compositional method, interrogating the metaphors of 'machine' and 'engine' as they relate to textual production.",
       "section": "Pataphysics",
       "category": "Vocabulary",
@@ -138188,8 +138188,8 @@
     },
     {
       "id": "pata-vocab-b1-gidouille",
-      "term": "gidouille",
-      "title": "Gidouille",
+      "term": "gidouille vocabulary entry",
+      "title": "Gidouille (Vocabulary Entry)",
       "description": "Père Ubu's immense belly, so big and singular in appetite that it required the invention of its own term. Represents Ubu's insatiable, infantile ego and embodiment of pure appetite and defecation. Part of Ubu's appearance along with three mismatched teeth and a retractable ear.",
       "section": "Pataphysics",
       "category": "Vocabulary",
@@ -138334,8 +138334,8 @@
     },
     {
       "id": "pata-vocab-b1-hermeneutic-paranoia",
-      "term": "hermeneutic paranoia",
-      "title": "Hermeneutic Paranoia",
+      "term": "hermeneutic paranoia vocabulary entry",
+      "title": "Hermeneutic Paranoia (Vocabulary Entry)",
       "description": "A compulsion induced by Faustroll to constantly search for hidden signs, symbols, and allusions. The text leads readers to see signs everywhere, interpret every aspect, suspect meaning under each particle of the work. One is immersed in an ocean of endless meaning and interconnection from the theological to the mathematical.",
       "section": "Pataphysics",
       "category": "Vocabulary",
@@ -138742,8 +138742,8 @@
     },
     {
       "id": "pata-vocab-b1-intraphysics",
-      "term": "intraphysics",
-      "title": "Intraphysics",
+      "term": "intraphysics vocabulary entry",
+      "title": "Intraphysics (Vocabulary Entry)",
       "description": "Boris Rybak's concept developed during the wartime period. Part of the pataphysical activities that occurred in the years leading up to the founding of the Collège de 'Pataphysique in 1948. Associated with the Main à Plume group and postwar surrealism.",
       "section": "Pataphysics",
       "category": "Vocabulary",
@@ -138950,7 +138950,7 @@
       "id": "duchamp-work-yvonne-in-kimono-1901",
       "term": "yvonne in kimono",
       "title": "Yvonne in Kimono",
-      "description": null,
+      "description": "Early portrait of Duchamp's sister Yvonne, made while he was still working within domestic and family subjects. The kimono costume points to the young artist's academic and illustrative formation before the conceptual breaks of the 1910s.",
       "image": "/images/duchamp/paintings/yvonne-in-kimono-1901.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -138970,13 +138970,13 @@
         "year": "1901"
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-portrait-of-yvonne-duchamp-1901",
-      "term": "portrait of yvonne duchamp",
-      "title": "Portrait of Yvonne Duchamp",
-      "description": null,
+      "term": "portrait of yvonne duchamp 1901",
+      "title": "Portrait of Yvonne Duchamp (1901)",
+      "description": "Early family portrait of Yvonne Duchamp. Useful as a baseline for Duchamp before Cubism, readymades, and The Large Glass: a conventional subject handled within the inherited language of portrait painting.",
       "image": "/images/duchamp/paintings/portrait-of-yvonne-duchamp-1901.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -138996,13 +138996,13 @@
         "year": "1901"
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-church-at-blainville-1902",
       "term": "church at blainville",
       "title": "Church at Blainville",
-      "description": null,
+      "description": "Early landscape view from Blainville, Duchamp's childhood environment in Normandy. The card preserves the provincial and observational ground from which his later anti-retinal and conceptual work would depart.",
       "image": "/images/duchamp/paintings/church-at-blainville-1902.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -139022,13 +139022,13 @@
         "year": "1902"
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-landscape-at-blainville-1902",
       "term": "landscape at blainville",
       "title": "Landscape at Blainville",
-      "description": null,
+      "description": "Early Blainville landscape, painted before Duchamp's move into modernist experimentation. It belongs to the conventional landscape practice that his later work would increasingly question and displace.",
       "image": "/images/duchamp/paintings/landscape-at-blainville-1902.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -139048,13 +139048,13 @@
         "year": "1902"
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-parva-domus-magna-quies-1902",
       "term": "parva domus magna quies",
       "title": "Parva Domus Magna Quies",
-      "description": null,
+      "description": "Early work whose Latin title means “small house, great peace.” It belongs to Duchamp's pre-avant-garde formation, before the irony of titles became one of his central artistic instruments.",
       "image": "/images/duchamp/paintings/parva-domus-magna-quies-1902.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -139074,13 +139074,13 @@
         "year": "1902"
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-play-1902",
       "term": "play",
       "title": "Play",
-      "description": null,
+      "description": "Early work from Duchamp's student period. In the gallery sequence it marks the ordinary pictorial beginnings that make the later turn toward chess, language, machines, and readymades more legible.",
       "image": "/images/duchamp/paintings/play-1902.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -139100,13 +139100,13 @@
         "year": "1902"
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-man-seated-by-a-window-1907",
       "term": "man seated by a window",
       "title": "Man Seated by a Window",
-      "description": null,
+      "description": "Early interior figure study. The seated figure and window motif keep the work within familiar painterly conventions, before Duchamp began making movement, delay, and perception themselves into the subject.",
       "image": "/images/duchamp/paintings/man-seated-by-a-window-1907.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -139126,13 +139126,13 @@
         "year": "1907"
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-chauvel-1910",
       "term": "chauvel",
       "title": "Chauvel",
-      "description": null,
+      "description": "Portrait from Duchamp's early mature period. It shows him still working through recognizable social portraiture at the moment just before the rapid 1911-1913 shift toward Cubist fracture and conceptual machinery.",
       "image": "/images/duchamp/paintings/chauvel-1910.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -139152,13 +139152,13 @@
         "year": "1910"
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-chess-game-1910",
       "term": "chess game",
       "title": "Chess Game",
-      "description": null,
+      "description": "Early painting of chess as a social and intellectual scene. The subject matters because chess later became one of Duchamp's lifelong practices and a key model for thinking art as rule, move, strategy, and endgame rather than retinal display.",
       "image": "/images/duchamp/paintings/chess-game-1910.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -139178,13 +139178,13 @@
         "year": "1910"
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-laundry-barge-1910",
       "term": "laundry barge",
       "title": "Laundry Barge",
-      "description": null,
+      "description": "Early urban-industrial scene. Its interest lies less in a single iconographic claim than in the way Duchamp was still painting observed modern life before converting modern machinery into conceptual apparatus.",
       "image": "/images/duchamp/paintings/laundry-barge-1910.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -139204,13 +139204,13 @@
         "year": "1910"
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-nude-with-black-stockings-1910",
       "term": "nude with black stockings",
       "title": "Nude with Black Stockings",
-      "description": null,
+      "description": "Early nude from the period before Duchamp's decisive break with conventional figure painting. It helps show the distance between ordinary studio eroticism and the later mechanical-erotic language of The Large Glass.",
       "image": "/images/duchamp/paintings/nude-with-black-stockings-1910.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -139230,13 +139230,13 @@
         "year": "1910"
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-portrait-of-dr-dumouchel-1910",
       "term": "portrait of dr dumouchel",
       "title": "Portrait of Dr. Dumouchel",
-      "description": null,
+      "description": "Portrait of Dr. Dumouchel, often noted as one of Duchamp's early modernist portraits. Its stylized handling shows the artist pushing beyond straightforward likeness toward psychological and pictorial distortion.",
       "image": "/images/duchamp/paintings/portrait-of-dr-dumouchel-1910.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -139256,13 +139256,13 @@
         "year": "1910"
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-portrait-of-dr-ferdinand-tribout-1910",
       "term": "portrait of dr ferdinand tribout",
       "title": "Portrait of Dr. Ferdinand Tribout",
-      "description": null,
+      "description": "Early portrait of Dr. Ferdinand Tribout. Preserved as part of Duchamp's portrait sequence before the Munich-period works and the conceptual turn that would make identity, title, and presentation unstable.",
       "image": "/images/duchamp/paintings/portrait-of-dr-ferdinand-tribout-1910.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -139282,13 +139282,13 @@
         "year": "1910"
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-portrait-of-the-artist-s-father-1910",
       "term": "portrait of the artists father",
       "title": "Portrait of the Artist's Father",
-      "description": null,
+      "description": "Portrait of Duchamp's father, Eugène Duchamp. A family portrait from the threshold of Duchamp's modernist period, useful for understanding the conventional painterly context he soon moved beyond.",
       "image": "/images/duchamp/paintings/portrait-of-the-artist-s-father-1910.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -139308,13 +139308,13 @@
         "year": "1910"
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-standing-nude-1910",
       "term": "standing nude",
       "title": "Standing Nude",
-      "description": null,
+      "description": "Early standing nude from Duchamp's pre-Large Glass development. The conventional studio subject becomes important by contrast with his later refusal of ordinary retinal nudes in favor of motion, mechanism, and delay.",
       "image": "/images/duchamp/paintings/standing-nude-1910.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -139334,13 +139334,13 @@
         "year": "1910"
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-standing-nude-1910-1",
       "term": "standing nude variant",
       "title": "Standing Nude (variant)",
-      "description": null,
+      "description": "Variant early standing nude. Kept separately in the artwork catalogue because it records Duchamp's repeated work through the academic nude before the figure is broken into movement and concept in the 1911-1912 paintings.",
       "image": "/images/duchamp/paintings/standing-nude-1910-1.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -139360,13 +139360,13 @@
         "year": "1910"
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-two-nudes-1910",
       "term": "two nudes",
       "title": "Two Nudes",
-      "description": null,
+      "description": "Early figure study with two nudes. It belongs to the body of work immediately preceding Duchamp's experiments with motion and decomposition, where the nude would become less a model than a problem of perception.",
       "image": "/images/duchamp/paintings/two-nudes-1910.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -139386,13 +139386,13 @@
         "year": "1910"
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-about-young-sister-1911",
       "term": "about young sister",
       "title": "About Young Sister",
-      "description": null,
+      "description": "1911 work centered on Duchamp's younger sister. It sits in the family/intimate strand of the major-period paintings, where figure, memory, and identity begin to loosen from conventional portraiture.",
       "image": "/images/duchamp/paintings/about-young-sister-1911.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -139412,13 +139412,13 @@
         "year": "1911"
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-baptism-1911",
       "term": "baptism",
       "title": "Baptism",
-      "description": null,
+      "description": "1911 painting from Duchamp's rapid experimental phase. Its title gives an ordinary image a ceremonial and symbolic charge, anticipating the way later works depend on titles to redirect what the viewer thinks they see.",
       "image": "/images/duchamp/paintings/baptism-1911.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -139438,13 +139438,13 @@
         "year": "1911"
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-japanese-apple-tree-1911",
       "term": "japanese apple tree",
       "title": "Japanese Apple Tree",
-      "description": null,
+      "description": "1911 painting whose title and motif show Duchamp still working through modernist pictorial subjects before The Large Glass. It belongs to the period when his paintings begin to test how naming changes the image.",
       "image": "/images/duchamp/paintings/japanese-apple-tree-1911.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -139464,13 +139464,13 @@
         "year": "1911"
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-landscape-study-for-paradise-1911",
       "term": "landscape study for paradise",
       "title": "Landscape Study for Paradise",
-      "description": null,
+      "description": "Landscape study connected to Duchamp's Paradise motif. It records the transitional 1911 moment when landscape and figure subjects were still present but increasingly unstable under modernist structure and irony.",
       "image": "/images/duchamp/paintings/landscape-study-for-paradise-1911.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -139490,13 +139490,13 @@
         "year": "1911"
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-portrait-dulcinea-1911",
       "term": "portrait dulcinea",
       "title": "Portrait Dulcinea",
-      "description": null,
+      "description": "1911 portrait named after Dulcinea, Don Quixote's imagined beloved. The literary title matters: Duchamp is already letting naming, projection, and desire complicate the supposedly direct act of portraiture.",
       "image": "/images/duchamp/paintings/portrait-dulcinea-1911.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -139516,13 +139516,13 @@
         "year": "1911"
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-the-chess-players-1911",
       "term": "the chess players",
       "title": "The Chess Players",
-      "description": null,
+      "description": "Major 1911 chess painting. It is an important bridge between Duchamp's family scenes, his Cubist experiments, and the later centrality of chess as a model of thought, rule-bound movement, and non-retinal art.",
       "image": "/images/duchamp/paintings/the-chess-players-1911.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -139542,13 +139542,13 @@
         "year": "1911"
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-yvonne-and-magdeleine-torn-in-tatters-1911",
       "term": "yvonne and magdeleine torn in tatters",
       "title": "Yvonne and Magdeleine Torn in Tatters",
-      "description": null,
+      "description": "1911 painting of Duchamp's sisters Yvonne and Magdeleine, fractured into torn, dynamic forms. The work is a key step from family portraiture toward the decomposition of bodies and identities that leads into Nude Descending a Staircase and The Large Glass.",
       "image": "/images/duchamp/paintings/yvonne-and-magdeleine-torn-in-tatters-1911.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -139568,13 +139568,13 @@
         "year": "1911"
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-portrait-of-gustave-candel-s-mother-1912",
       "term": "portrait of gustave candels mother",
       "title": "Portrait of Gustave Candel's Mother",
-      "description": null,
+      "description": "1912 portrait from the period of Duchamp's most intense pre-Glass experimentation. It preserves his continued engagement with portraiture even as his central concerns were shifting toward movement, machines, and conceptual structure.",
       "image": "/images/duchamp/paintings/portrait-of-gustave-candel-s-mother-1912.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -139594,13 +139594,13 @@
         "year": "1912"
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-bicycle-wheel-1913",
       "term": "bicycle wheel",
       "title": "Bicycle Wheel",
-      "description": null,
+      "description": "Duchamp's 1913 Bicycle Wheel, a wheel mounted on a stool, is often treated as the first readymade. It matters because it turns ordinary manufactured objects into a contemplative and anti-retinal apparatus rather than a handmade image.",
       "image": "/images/duchamp/paintings/bicycle-wheel-1913.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -139620,13 +139620,13 @@
         "year": "1913"
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-bottlerack-1914",
       "term": "bottlerack",
       "title": "Bottlerack",
-      "description": null,
+      "description": "1914 readymade consisting of a commercial bottle rack selected and presented as art. It is central to Duchamp's challenge to taste, craft, and authorship, and to later questions about whether his readymades were merely found or carefully staged.",
       "image": "/images/duchamp/paintings/bottlerack-1914.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -139646,13 +139646,13 @@
         "year": "1914"
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-glider-containing-a-water-mill-in-neighboring-metals-1915",
       "term": "glider containing a water mill in neighboring metals",
       "title": "Glider Containing a Water Mill in Neighboring Metals",
-      "description": null,
+      "description": "Study related to The Large Glass, focusing on the glider and water mill apparatus in the Bachelor realm. It is useful for reading the Glass as a technical system rather than a single mysterious image.",
       "image": "/images/duchamp/paintings/glider-containing-a-water-mill-in-neighboring-metals-1915.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -139672,13 +139672,13 @@
         "year": "1915"
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-in-advance-of-the-broken-arm-1915",
       "term": "in advance of the broken arm",
       "title": "In Advance of the Broken Arm",
-      "description": null,
+      "description": "1915 readymade snow shovel. Its title turns an ordinary tool into a time-looping joke: the object is named not for what it is but for an injury it might prevent or anticipate.",
       "image": "/images/duchamp/paintings/in-advance-of-the-broken-arm-1915.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -139698,13 +139698,13 @@
         "year": "1915"
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-apolinere-enamelled-1916",
       "term": "apolinere enameled",
       "title": "Apolinère Enameled",
-      "description": null,
+      "description": "1916 assisted readymade based on an enamel paint advertisement, with Duchamp altering image and language. The misspelled title turns Guillaume Apollinaire into a punning commercial surface, joining wordplay to the readymade.",
       "image": "/images/duchamp/paintings/apolinere-enamelled-1916.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -139724,13 +139724,13 @@
         "year": "1916"
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-with-hidden-noise-1916",
       "term": "with hidden noise",
       "title": "With Hidden Noise",
-      "description": null,
+      "description": "Assisted readymade made with a ball of twine between brass plates and an unknown object hidden inside. Its secret sound makes the work depend on concealed information, collaboration, and the viewer's inability to fully know the object.",
       "image": "/images/duchamp/paintings/with-hidden-noise-1916.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -139750,13 +139750,13 @@
         "year": "1916"
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-fountain-1917",
       "term": "fountain",
       "title": "Fountain",
-      "description": null,
+      "description": "The 1917 urinal signed R. Mutt, one of the defining readymades of twentieth-century art. Fountain makes selection, naming, context, and institutional refusal part of the work, rather than treating art as a crafted retinal object.",
       "image": "/images/duchamp/paintings/fountain-1917.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -139776,13 +139776,13 @@
         "year": "1917"
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-to-be-looked-at-from-the-other-side-of-the-glass-with-one-eye-close-to-for-almost-an-hour-1918",
       "term": "to be looked at from the other side of the glass",
       "title": "To Be Looked at (from the Other Side of the Glass)",
-      "description": null,
+      "description": "1918 glass work whose title is also an instruction for viewing. It directly anticipates the optical and procedural demands of The Large Glass, making perception slow, awkward, embodied, and rule-bound.",
       "image": "/images/duchamp/paintings/to-be-looked-at-from-the-other-side-of-the-glass-with-one-eye-close-to-for-almost-an-hour-1918.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -139802,13 +139802,13 @@
         "year": "1918"
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-50-cc-of-paris-air-1919",
       "term": "50 cc of paris air",
       "title": "50 cc of Paris Air",
-      "description": null,
+      "description": "Readymade ampoule said to contain Paris air, brought to America as a fragile souvenir. It makes absence, atmosphere, and place into an object, turning almost nothing into a portable conceptual charge.",
       "image": "/images/duchamp/paintings/50-cc-of-paris-air-1919.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -139828,13 +139828,13 @@
         "year": "1919"
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-fresh-widow-1920",
       "term": "fresh widow",
       "title": "Fresh Widow",
-      "description": null,
+      "description": "1920 miniature French window with panes covered in black leather. The title puns on “French window” and widowhood, making architecture, mourning, erotic withholding, and wordplay converge in a small readymade object.",
       "image": "/images/duchamp/paintings/fresh-widow-1920.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -139854,13 +139854,13 @@
         "year": "1920"
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-rotary-glass-plates-precision-optics-1920",
       "term": "rotary glass plates precision optics",
       "title": "Rotary Glass Plates (Precision Optics)",
-      "description": null,
+      "description": "Optical machine of rotating glass plates designed to generate visual effects. It belongs to Duchamp's post-Glass interest in precision optics, motion, and machines that make seeing itself unstable.",
       "image": "/images/duchamp/paintings/rotary-glass-plates-precision-optics-1920.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -139880,13 +139880,13 @@
         "year": "1920"
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-the-brawl-at-austerlitz-1921",
       "term": "the brawl at austerlitz",
       "title": "The Brawl at Austerlitz",
-      "description": null,
+      "description": "1921 readymade or assisted readymade punning on “gare d'Austerlitz” and a brawl. Like many late readymades, its force lies in the collision between object, language, urban reference, and absurd title.",
       "image": "/images/duchamp/paintings/the-brawl-at-austerlitz-1921.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -139906,13 +139906,13 @@
         "year": "1921"
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-disks-bearing-spirals-1923",
       "term": "disks bearing spirals",
       "title": "Disks Bearing Spirals",
-      "description": null,
+      "description": "Optical work with spiral disks, part of Duchamp's experiments with rotation and perceptual illusion. These works extend his attack on static retinal painting by making vision mechanical, temporal, and unstable.",
       "image": "/images/duchamp/paintings/disks-bearing-spirals-1923.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -139932,13 +139932,13 @@
         "year": "1923"
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-monte-carlo-bond-1924",
       "term": "monte carlo bond",
       "title": "Monte Carlo Bond",
-      "description": null,
+      "description": "1924 mock financial bond issued by Duchamp for a roulette system, with Man Ray's photograph of the artist as Rrose Sélavy. It fuses chance, finance, persona, gambling, and art into a deliberately unstable contract.",
       "image": "/images/duchamp/paintings/monte-carlo-bond-1924.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -139958,13 +139958,13 @@
         "year": "1924"
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-rotary-demisphere-1925",
       "term": "rotary demisphere",
       "title": "Rotary Demisphere",
-      "description": null,
+      "description": "Motorized optical object subtitled Precision Optics. Its rotating hemispherical form continues Duchamp's interest in machines for producing visual instability and in art as a device rather than a picture.",
       "image": "/images/duchamp/paintings/rotary-demisphere-1925.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -139984,13 +139984,13 @@
         "year": "1925"
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-cover-design-for-view-magazine-1945",
       "term": "cover design for view magazine",
       "title": "Cover Design for View Magazine",
-      "description": null,
+      "description": "Cover design for View magazine from Duchamp's later Surrealist network. It belongs to the period when Duchamp often worked through publications, exhibitions, and design interventions rather than conventional standalone paintings.",
       "image": "/images/duchamp/paintings/cover-design-for-view-magazine-1945.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -140010,13 +140010,13 @@
         "year": "1945"
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-please-touch-cover-design-for-le-surrealisme-1947",
       "term": "please touch cover design for le surrealisme",
       "title": "Please Touch (Cover Design for Le Surréalisme)",
-      "description": null,
+      "description": "Cover for Le Surréalisme en 1947 featuring a foam breast under the instruction “Please Touch.” The work reverses the museum rule against touching and turns erotic contact, reproduction, and exhibition design into the artwork.",
       "image": "/images/duchamp/paintings/please-touch-cover-design-for-le-surrealisme-1947.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -140036,13 +140036,13 @@
         "year": "1947"
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-self-portrait-in-profile-1958",
       "term": "self portrait in profile",
       "title": "Self Portrait in Profile",
-      "description": null,
+      "description": "Late self-portrait reduced to a profile silhouette. It shows Duchamp treating identity as outline, trace, and graphic sign rather than expressive likeness, consistent with his long suspicion of direct self-display.",
       "image": "/images/duchamp/paintings/self-portrait-in-profile-1958.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -140062,13 +140062,13 @@
         "year": "1958"
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-study-for-given-1-the-waterfall-2-illuminating-gas",
       "term": "study for given 1 the waterfall 2 illuminating gas",
       "title": "Study for Given: 1. The Waterfall, 2. Illuminating Gas",
-      "description": null,
+      "description": "Study for Étant donnés: 1. The Waterfall, 2. The Illuminating Gas, Duchamp's final major work. It connects the later secret installation back to the Glass through illumination, erotic staging, and controlled viewing.",
       "image": "/images/duchamp/paintings/study-for-given-1-the-waterfall-2-illuminating-gas.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -140087,13 +140087,13 @@
         "displayOrder": 65
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-the-bec-auer-1967",
       "term": "the bec auer",
       "title": "The Bec Auer",
-      "description": null,
+      "description": "Late work referring to the Auer gas lamp or burner. It belongs to Duchamp's continued return to illuminating gas, one of the key materials and motifs linking Étant donnés back to The Large Glass.",
       "image": "/images/duchamp/paintings/the-bec-auer-1967.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -140113,13 +140113,13 @@
         "year": "1967"
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-selected-details-after-cranach-1968",
       "term": "selected details after cranach",
       "title": "Selected Details After Cranach",
-      "description": null,
+      "description": "Late work after Lucas Cranach, made at the end of Duchamp's life. The selective quotation of an older image fits his long practice of appropriation, erotic displacement, and making art history available for conceptual reuse.",
       "image": "/images/duchamp/paintings/selected-details-after-cranach-1968.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -140139,13 +140139,13 @@
         "year": "1968"
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-portrait-of-jacques-villon",
       "term": "portrait of jacques villon",
       "title": "Portrait of Jacques Villon",
-      "description": null,
+      "description": "Undated portrait of Jacques Villon, Duchamp's elder brother and fellow artist. The card preserves the family network that shaped Duchamp's early artistic formation before his break into readymades and conceptual work.",
       "image": "/images/duchamp/paintings/portrait-of-jacques-villon.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -140164,13 +140164,13 @@
         "displayOrder": 71
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-portrait-of-yvonne-duchamp",
-      "term": "portrait of yvonne duchamp",
-      "title": "Portrait of Yvonne Duchamp",
-      "description": null,
+      "term": "portrait of yvonne duchamp undated",
+      "title": "Portrait of Yvonne Duchamp (Undated)",
+      "description": "Undated portrait of Yvonne Duchamp. Kept separately from the dated 1901 portrait because the catalogue treats it as a distinct work in the family portrait group, even though both share the same sitter.",
       "image": "/images/duchamp/paintings/portrait-of-yvonne-duchamp.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -140189,13 +140189,13 @@
         "displayOrder": 72
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     },
     {
       "id": "duchamp-work-the-bush",
       "term": "the bush",
       "title": "The Bush",
-      "description": null,
+      "description": "Undated work titled The Bush. With limited metadata, it is best treated conservatively as a catalogued Duchamp artwork whose importance here is as part of the complete gallery record rather than as a major thesis anchor.",
       "image": "/images/duchamp/paintings/the-bush.jpg",
       "images": [],
       "section": "Marcel Duchamp",
@@ -140214,7 +140214,7 @@
         "displayOrder": 73
       },
       "createdAt": "2026-04-24T00:00:00.000Z",
-      "updatedAt": "2026-04-24T00:00:00.000Z"
+      "updatedAt": "2026-05-01T23:52:30.000Z"
     }
   ]
 }

--- a/docs/ai-appraisal-prose-review.md
+++ b/docs/ai-appraisal-prose-review.md
@@ -1,0 +1,49 @@
+# AI appraisal prose review for issue #45
+
+Issue: <https://github.com/dalten-collective/elden-glass/issues/45>
+
+## Procedure note
+
+The issue asks for repeated fresh web-based Claude and ChatGPT sessions using the production homepage prompt. In this coding harness, authenticated browser sessions for those web products are not guaranteed. I therefore used the production prompt and the local/production site corpus to produce an internal composite AI-style appraisal, then captured the result as a Critiques entry rather than making unverified claims about specific external model sessions.
+
+If a later human pass runs the exact web-Claude/web-ChatGPT procedure, this document should be updated with session-specific notes.
+
+## Recurring prose/thesis weaknesses identified
+
+1. **The thesis can sound over-certain before the evidence has accumulated.**
+   The literal framing is core to the project, but skeptical readers need earlier visibility into the standard of proof.
+
+2. **Evidence hierarchy needs to be clearer.**
+   Anchor correspondences should be distinguished from atmospheric echoes. The reader should know which claims are load-bearing.
+
+3. **The method can look unfalsifiable.**
+   The thesis needs explicit constraints for what counts as a valid correspondence and what would be weak evidence.
+
+4. **Medium translation needs to remain central.**
+   The strongest version of the claim is not that the game depicts the Glass, but that it spatializes and temporalizes the Glass apparatus.
+
+5. **The tone can make skeptical readers defensive.**
+   The project should keep its declarative identity while offering more hospitality around method and evaluation.
+
+## Classification
+
+- Living Thesis / document edit:
+  - Add a short methodological paragraph near the opening of the Living Thesis clarifying cumulative evidence, load-bearing correspondences, and the standard of evaluation.
+
+- Critiques response:
+  - A longer response belongs in Critiques because the objections are methodological and interpretive rather than simple prose fixes.
+
+- AX / implementation:
+  - No implementation issue was created from this pass. Navigation and agent-experience concerns were not the focus of this synthesized appraisal.
+
+## Action taken
+
+Created `content/critiques/composite-ai-appraisal.md`, a Critiques entry that responds to the strongest recurring objections without turning the Living Thesis into a defensive FAQ.
+
+## Recommended follow-up
+
+Add a concise paragraph to `content/pages/living-thesis.mdx` after the initial evidentiary framing. Suggested intent:
+
+> The argument should be judged cumulatively. A single correspondence may be metaphor; a dense, ordered set of correspondences keyed to named mechanisms in Duchamp's notes is a different kind of evidence. Not every echo is load-bearing, and the strongest correspondences are the ones that perform the same structural work in both systems.
+
+That edit should be made carefully in the author's voice.


### PR DESCRIPTION
## Summary

This PR restacks only the content/data portions of the prior issue work onto current `dev`.

It includes:

- A new critique page responding to the composite AI prose appraisal.
- A supporting prose-review note documenting which appraisal points were acted on and which were intentionally resisted.
- A short Living Thesis method note about using adversarial/composite AI critique as pressure-testing rather than authority.
- Conservative item-card data cleanup:
  - disambiguates exact duplicate `title`/`term` clusters where cards represent distinct senses, sections, or uses
  - classifies previously unclassified root cards
  - fills The Green Box description
  - expands short non-import Duchamp/Large Glass descriptions

## Intentional exclusions

This PR intentionally excludes the prior agent's non-content/config work:

- no Vercel workflow changes
- no deployment docs/config changes
- no `package.json` script changes
- no updated-date drift script
- no direct `main` changes

## Validation

Ran locally:

```bash
npm run check
```

Item-card audit after cleanup:

- exact duplicate titles: `0`
- exact duplicate terms: `0`
- cards missing section/category: `0`
- short non-Elden descriptions: `0`

## Review

Per `AGENTS.md`, this touches structured data and critique docs, so it requires review by `rabsef-bicrym` and should not be merged by the agent.

Closes #45
Closes #48
Closes #51
