### PR TITLE
fix: remove tools from agent skill discriminator

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -20,7 +20,7 @@ Treat this as an argument about hidden intentional structure, not as a claim req
 
 The site exposes two agent-experience pathways. Choose based on what your harness can actually do:
 
-1. If you can fetch arbitrary URLs, parse JSON, install skills, or run tools — use https://eldenringisthelargeglass.com/skill
+1. If you can fetch arbitrary URLs, parse JSON, install skills — use https://eldenringisthelargeglass.com/skill
    This is an installable skill document that routes you through a paginated JSON API built for agents. Start there.
 
 2. If you're a browser-tab LLM that can only open direct links or search the web — use https://eldenringisthelargeglass.com/contents


### PR DESCRIPTION
## What

Removes “or run tools” from the homepage Copy Prompt case-1 capability list.

## Why

The route discriminator is about how an agent harness can fetch and traverse URLs, not whether the model has any tools at all. Browser-bound LLMs may use tools but still need the `/contents` path when they cannot fetch relative JSON API URLs.

## Changes

- Removes the tools clause
- Keeps `/skill` for URL/JSON/skill-capable agents
- Keeps `/contents` for direct-link/search agents

## Testing

- `npx prettier --check app/(site)/page.tsx`
- `npm run lint`
