### PR TITLE
refactor: promote search style-system slice

### DIFF
--- a/app/(site)/search/page.tsx
+++ b/app/(site)/search/page.tsx
@@ -125,35 +125,35 @@ function SearchContent() {
   return (
     <div className="min-h-screen">
       {/* Header */}
-      <div className="border-b border-[var(--border-subtle)] bg-[var(--bg-secondary)] px-6 py-8">
+      <div className="search-page-header px-6 py-8">
         <div className="max-w-4xl mx-auto">
-          <h1 className="text-3xl font-serif text-[var(--accent-gold)] mb-4">Search</h1>
+          <h1 className="search-page-title mb-4">Search</h1>
 
           {/* Search Input */}
           <form onSubmit={handleSubmit} className="relative">
-            <Search className="absolute left-4 top-1/2 -translate-y-1/2 h-5 w-5 text-[var(--text-tertiary)]" />
+            <Search className="search-page-input-icon absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2" />
             <input
               type="text"
               value={searchInput}
               onChange={(e) => setSearchInput(e.target.value)}
               placeholder="Search the site..."
               autoFocus
-              className="w-full pl-12 pr-12 py-4 bg-[var(--bg-primary)] border border-[var(--border-subtle)] rounded-lg text-lg text-[var(--text-primary)] placeholder:text-[var(--text-tertiary)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-gold)] focus:border-transparent"
+              className="search-page-input w-full py-4 pl-12 pr-12 text-lg focus:outline-none"
             />
             {searchInput && (
               <button
                 type="button"
                 onClick={handleClear}
-                className="absolute right-4 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)] hover:text-[var(--text-primary)]"
+                className="search-page-clear absolute right-4 top-1/2 -translate-y-1/2"
               >
                 <X className="h-5 w-5" />
               </button>
             )}
           </form>
 
-          <p className="text-sm text-[var(--text-tertiary)] mt-3">
+          <p className="search-page-note mt-3 text-sm">
             Search through all documents and pages. For item cards, use{' '}
-            <Link href="/gatherer" className="text-[var(--accent-gold)] hover:underline">
+            <Link href="/gatherer" className="search-page-link">
               Item Cards
             </Link>
             .
@@ -175,7 +175,7 @@ function SearchContent() {
         {/* Results List */}
         {!loading && results.length > 0 && (
           <div className="space-y-1">
-            <p className="text-sm text-[var(--text-tertiary)] mb-6">
+            <p className="search-page-count mb-6 text-sm">
               Showing {(urlPage - 1) * 20 + 1}-{Math.min(urlPage * 20, total)} of {total} result
               {total !== 1 ? 's' : ''} for &quot;{urlQuery}&quot;
             </p>
@@ -202,11 +202,11 @@ function SearchContent() {
         {/* No Results */}
         {!loading && urlQuery && results.length === 0 && (
           <div className="text-center py-16">
-            <FileText className="h-12 w-12 text-[var(--text-tertiary)] mx-auto mb-4" />
-            <p className="text-[var(--text-secondary)] mb-2">
+            <FileText className="search-page-empty-icon mx-auto mb-4 h-12 w-12" />
+            <p className="search-page-empty-title mb-2">
               No results found for &quot;{urlQuery}&quot;
             </p>
-            <p className="text-sm text-[var(--text-tertiary)]">
+            <p className="search-page-empty-copy text-sm">
               Try different keywords or check your spelling
             </p>
           </div>
@@ -215,8 +215,8 @@ function SearchContent() {
         {/* Initial State */}
         {!loading && !urlQuery && (
           <div className="text-center py-16">
-            <Search className="h-12 w-12 text-[var(--text-tertiary)] mx-auto mb-4" />
-            <p className="text-[var(--text-secondary)]">
+            <Search className="search-page-empty-icon mx-auto mb-4 h-12 w-12" />
+            <p className="search-page-empty-title">
               Enter a search term to find content across the site
             </p>
           </div>
@@ -248,20 +248,20 @@ const SearchResultItem = memo(function SearchResultItem({
           resultType: 'content',
         })
       }
-      className="block p-4 -mx-4 rounded-lg hover:bg-[var(--bg-secondary)] transition group"
+      className="search-result-item group -mx-4 block p-4"
     >
       {/* Page Title */}
       <div className="flex items-center gap-2 mb-2">
-        <FileText className="h-4 w-4 text-[var(--accent-gold)]" />
-        <span className="text-sm font-medium text-[var(--accent-gold)]">{result.pageTitle}</span>
-        <ArrowRight className="h-3 w-3 text-[var(--text-tertiary)] opacity-0 group-hover:opacity-100 transition" />
+        <FileText className="search-result-icon h-4 w-4" />
+        <span className="search-result-page text-sm font-medium">{result.pageTitle}</span>
+        <ArrowRight className="search-result-arrow h-3 w-3 opacity-0 transition group-hover:opacity-100" />
       </div>
 
       {/* Matched Sentence */}
-      <p className="text-[var(--text-primary)] mb-1">{highlightMatch(result.sentence, query)}</p>
+      <p className="search-result-sentence mb-1">{highlightMatch(result.sentence, query)}</p>
 
       {/* Context */}
-      <p className="text-sm text-[var(--text-tertiary)] line-clamp-2">{result.context}</p>
+      <p className="search-result-context line-clamp-2 text-sm">{result.context}</p>
     </Link>
   );
 });
@@ -314,28 +314,26 @@ const Pagination = memo(function Pagination({
   };
 
   return (
-    <div className="flex items-center justify-center gap-2 mt-8 pt-6 border-t border-[var(--border-subtle)]">
+    <div className="search-pagination mt-8 flex items-center justify-center gap-2 pt-6">
       <button
         onClick={() => onPageChange(currentPage - 1)}
         disabled={currentPage === 1}
-        className="p-2 rounded-lg border border-[var(--border-subtle)] text-[var(--text-secondary)] hover:bg-[var(--bg-secondary)] disabled:opacity-50 disabled:cursor-not-allowed transition"
+        className="search-pagination-arrow p-2"
       >
         <ChevronLeft className="h-4 w-4" />
       </button>
 
       {getPageNumbers().map((page, index) =>
         page === 'ellipsis' ? (
-          <span key={`ellipsis-${index}`} className="px-2 text-[var(--text-tertiary)]">
+          <span key={`ellipsis-${index}`} className="search-pagination-ellipsis px-2">
             ...
           </span>
         ) : (
           <button
             key={page}
             onClick={() => onPageChange(page)}
-            className={`min-w-[40px] h-10 rounded-lg border transition ${
-              page === currentPage
-                ? 'border-[var(--accent-gold)] bg-[var(--accent-gold)]/10 text-[var(--accent-gold)]'
-                : 'border-[var(--border-subtle)] text-[var(--text-secondary)] hover:bg-[var(--bg-secondary)]'
+            className={`search-pagination-page h-10 min-w-[40px] ${
+              page === currentPage ? 'is-active' : ''
             }`}
           >
             {page}
@@ -346,7 +344,7 @@ const Pagination = memo(function Pagination({
       <button
         onClick={() => onPageChange(currentPage + 1)}
         disabled={currentPage === totalPages}
-        className="p-2 rounded-lg border border-[var(--border-subtle)] text-[var(--text-secondary)] hover:bg-[var(--bg-secondary)] disabled:opacity-50 disabled:cursor-not-allowed transition"
+        className="search-pagination-arrow p-2"
       >
         <ChevronRight className="h-4 w-4" />
       </button>
@@ -360,10 +358,7 @@ function highlightMatch(text: string, query: string): React.ReactNode {
   const parts = text.split(new RegExp(`(${escapeRegex(query)})`, 'gi'));
   return parts.map((part, index) =>
     part.toLowerCase() === query.toLowerCase() ? (
-      <mark
-        key={index}
-        className="bg-[var(--accent-gold)]/30 text-[var(--text-primary)] px-0.5 rounded"
-      >
+      <mark key={index} className="search-highlight px-0.5">
         {part}
       </mark>
     ) : (
@@ -379,10 +374,10 @@ function escapeRegex(string: string) {
 function SearchSkeleton() {
   return (
     <div className="min-h-screen">
-      <div className="border-b border-[var(--border-subtle)] bg-[var(--bg-secondary)] px-6 py-8">
+      <div className="search-page-header px-6 py-8">
         <div className="max-w-4xl mx-auto">
-          <div className="h-9 w-32 bg-[var(--bg-primary)] rounded animate-pulse mb-4" />
-          <div className="h-14 w-full bg-[var(--bg-primary)] rounded-lg animate-pulse" />
+          <div className="search-skeleton mb-4 h-9 w-32 animate-pulse" />
+          <div className="search-skeleton h-14 w-full animate-pulse" />
         </div>
       </div>
       <div className="max-w-4xl mx-auto px-6 py-8">
@@ -399,9 +394,9 @@ function SearchSkeleton() {
 function ResultSkeleton() {
   return (
     <div className="p-4 animate-pulse">
-      <div className="h-4 w-32 bg-[var(--bg-secondary)] rounded mb-3" />
-      <div className="h-5 w-full bg-[var(--bg-secondary)] rounded mb-2" />
-      <div className="h-4 w-3/4 bg-[var(--bg-secondary)] rounded" />
+      <div className="search-skeleton mb-3 h-4 w-32" />
+      <div className="search-skeleton mb-2 h-5 w-full" />
+      <div className="search-skeleton h-4 w-3/4" />
     </div>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1658,6 +1658,170 @@ body {
   text-transform: uppercase;
 }
 
+/* Search surfaces — shared page and global-search composition over Delay
+   tokens. These classes intentionally replace older legacy-token Tailwind
+   recipes without changing the search interaction model. */
+.search-page-header {
+  border-bottom: 1px solid var(--pane-edge);
+  background: var(--ink-2);
+}
+.search-page-title {
+  color: var(--gold);
+  font-family: var(--font-serif);
+  font-size: 30px;
+  line-height: 1.2;
+}
+.search-page-input-icon,
+.search-page-clear,
+.search-page-note,
+.search-page-count,
+.search-result-arrow,
+.search-result-context,
+.search-pagination-ellipsis,
+.search-page-empty-icon,
+.global-search-icon-button,
+.global-search-clear,
+.global-search-empty,
+.global-search-result-meta,
+.global-search-result-context,
+.global-search-footer {
+  color: var(--paper-dimmer);
+}
+.search-page-clear,
+.global-search-icon-button,
+.global-search-clear {
+  transition: color 0.15s ease;
+}
+.search-page-clear:hover,
+.global-search-clear:hover {
+  color: var(--paper);
+}
+.global-search-icon-button:hover {
+  color: var(--gold);
+}
+.search-page-input,
+.global-search-input {
+  border: 1px solid var(--pane-edge);
+  border-radius: 8px;
+  background: var(--ink);
+  color: var(--paper);
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
+}
+.search-page-input::placeholder,
+.global-search-input::placeholder {
+  color: var(--paper-dimmer);
+}
+.search-page-input:focus,
+.global-search-input:focus {
+  border-color: transparent;
+  box-shadow: 0 0 0 2px var(--gold);
+}
+.global-search-input {
+  background: color-mix(in srgb, var(--ink-2) 50%, transparent);
+}
+.search-page-link,
+.search-result-icon,
+.search-result-page,
+.global-search-result-page {
+  color: var(--gold);
+}
+.search-page-link:hover {
+  text-decoration: underline;
+}
+.search-page-empty-title,
+.search-result-sentence,
+.global-search-result-sentence {
+  color: var(--paper);
+}
+.search-page-empty-copy {
+  color: var(--paper-dimmer);
+}
+.search-result-item {
+  border-radius: 8px;
+  transition: background 0.15s ease;
+}
+.search-result-item:hover {
+  background: var(--ink-2);
+}
+.search-pagination {
+  border-top: 1px solid var(--pane-edge);
+}
+.search-pagination-arrow,
+.search-pagination-page {
+  border: 1px solid var(--pane-edge);
+  border-radius: 8px;
+  color: var(--paper-dim);
+  cursor: pointer;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease;
+}
+.search-pagination-arrow:hover,
+.search-pagination-page:hover {
+  background: var(--ink-2);
+}
+.search-pagination-arrow:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+.search-pagination-page.is-active {
+  border-color: var(--gold);
+  background: color-mix(in srgb, var(--gold) 12%, transparent);
+  color: var(--gold);
+}
+.search-highlight {
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--gold) 30%, transparent);
+  color: var(--paper);
+}
+.search-skeleton {
+  border-radius: 8px;
+  background: var(--ink-2);
+}
+.global-search-dropdown {
+  border: 1px solid var(--pane-edge);
+  background: var(--ink-2);
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.8);
+}
+.global-search-dropdown--topbar {
+  border-color: color-mix(in srgb, var(--pane-edge) 90%, var(--gold) 10%);
+  border-radius: 8px;
+}
+.global-search-result {
+  border-bottom: 1px solid var(--pane-edge);
+  border-left: 2px solid transparent;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease;
+}
+.global-search-result:last-child {
+  border-bottom: 0;
+}
+.global-search-result:hover {
+  background: color-mix(in srgb, var(--ink) 50%, transparent);
+}
+.global-search-result.is-selected {
+  border-left-color: var(--gold);
+  background: color-mix(in srgb, var(--gold) 10%, transparent);
+}
+.global-search-badge {
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--gold) 20%, transparent);
+  color: var(--gold);
+}
+.global-search-footer {
+  border-top: 1px solid var(--pane-edge);
+  background: color-mix(in srgb, var(--ink) 50%, transparent);
+}
+.global-search-highlight {
+  border-radius: 3px;
+  background: var(--gold);
+  color: var(--ink);
+}
+
 /* Inline item-card previews render in a document-body portal, so these
    classes are intentionally unscoped while still using Delay tokens. */
 .item-card-trigger {

--- a/components/site/global-search.tsx
+++ b/components/site/global-search.tsx
@@ -187,7 +187,7 @@ export function GlobalSearch({
         <button
           onClick={goToSearchPage}
           type="button"
-          className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)] hover:text-[var(--accent-gold)] transition-colors z-10"
+          className="global-search-icon-button absolute left-3 top-1/2 z-10 -translate-y-1/2"
         >
           <Search className="h-4 w-4" />
         </button>
@@ -201,12 +201,12 @@ export function GlobalSearch({
             shouldShowPreview && query.length >= 2 && results.length > 0 && setIsOpen(true)
           }
           placeholder="Search the site..."
-          className="w-full pl-10 pr-10 py-2 bg-[rgb(var(--bg-secondary-rgb)/0.5)] border border-[var(--border-subtle)] rounded-lg text-sm text-[var(--text-primary)] placeholder:text-[var(--text-tertiary)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-gold)] focus:border-transparent transition-all"
+          className="global-search-input w-full py-2 pl-10 pr-10 text-sm focus:outline-none"
         />
         {query && (
           <button
             onClick={handleClear}
-            className="absolute right-3 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)] hover:text-[var(--text-primary)] transition-colors"
+            className="global-search-clear absolute right-3 top-1/2 -translate-y-1/2"
           >
             <X className="h-4 w-4" />
           </button>
@@ -218,16 +218,14 @@ export function GlobalSearch({
         <div
           className={
             variant === 'sidebar'
-              ? 'absolute left-0 right-0 top-full mt-2 max-h-[60vh] overflow-y-auto border border-[var(--pane-edge)] bg-[var(--ink-2)] shadow-2xl z-[100]'
-              : 'absolute top-full mt-2 w-full bg-[var(--bg-secondary)] border border-[var(--border-emphasis)] rounded-lg shadow-2xl overflow-hidden z-50 max-h-[70vh] overflow-y-auto'
+              ? 'global-search-dropdown global-search-dropdown--sidebar absolute left-0 right-0 top-full z-[100] mt-2 max-h-[60vh] overflow-y-auto'
+              : 'global-search-dropdown global-search-dropdown--topbar absolute top-full z-50 mt-2 max-h-[70vh] w-full overflow-hidden overflow-y-auto'
           }
         >
           {isLoading ? (
-            <div className="p-4 text-center text-sm text-[var(--text-tertiary)]">Searching...</div>
+            <div className="global-search-empty p-4 text-center text-sm">Searching...</div>
           ) : results.length === 0 ? (
-            <div className="p-4 text-center text-sm text-[var(--text-tertiary)]">
-              No results found
-            </div>
+            <div className="global-search-empty p-4 text-center text-sm">No results found</div>
           ) : (
             <div>
               {results.map((result, index) => (
@@ -235,38 +233,36 @@ export function GlobalSearch({
                   key={result.id}
                   onClick={() => handleSelectResult(result, index)}
                   onMouseEnter={() => setSelectedIndex(index)}
-                  className={`w-full text-left px-4 py-3 border-b border-[var(--border-subtle)] last:border-b-0 transition-colors ${
-                    index === selectedIndex
-                      ? 'bg-[rgb(var(--accent-gold-rgb)/0.1)] border-l-2 border-l-[var(--accent-gold)]'
-                      : 'hover:bg-[rgb(var(--bg-primary-rgb)/0.5)]'
+                  className={`global-search-result w-full px-4 py-3 text-left ${
+                    index === selectedIndex ? 'is-selected' : ''
                   }`}
                 >
                   {/* Item Card badge or Page Title */}
                   <div className="flex items-center gap-2 mb-1">
                     {result.type === 'itemcard' ? (
-                      <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-[rgb(var(--accent-gold-rgb)/0.2)] text-[var(--accent-gold)] text-[10px] uppercase tracking-[0.1em] font-medium rounded">
+                      <span className="global-search-badge inline-flex items-center gap-1 px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.1em]">
                         <BookText className="h-3 w-3" />
                         Definition
                       </span>
                     ) : (
-                      <span className="text-[10px] uppercase tracking-[0.15em] text-[var(--accent-gold)] font-light">
+                      <span className="global-search-result-page text-[10px] font-light uppercase tracking-[0.15em]">
                         {result.pageTitle}
                       </span>
                     )}
                     {result.type === 'itemcard' && result.pageTitle && (
-                      <span className="text-[10px] text-[var(--text-tertiary)]">
+                      <span className="global-search-result-meta text-[10px]">
                         {result.pageTitle}
                       </span>
                     )}
                   </div>
 
                   {/* Sentence/Match */}
-                  <div className="text-sm text-[var(--text-primary)] font-medium mb-1 line-clamp-2">
+                  <div className="global-search-result-sentence mb-1 line-clamp-2 text-sm font-medium">
                     {highlightMatch(result.sentence, query)}
                   </div>
 
                   {/* Context */}
-                  <div className="text-xs text-[var(--text-tertiary)] line-clamp-2">
+                  <div className="global-search-result-context line-clamp-2 text-xs">
                     {result.context}
                   </div>
                 </button>
@@ -275,7 +271,7 @@ export function GlobalSearch({
           )}
 
           {/* Footer with keyboard shortcuts */}
-          <div className="px-4 py-2 bg-[rgb(var(--bg-primary-rgb)/0.5)] border-t border-[var(--border-subtle)] flex items-center justify-between text-[10px] text-[var(--text-tertiary)]">
+          <div className="global-search-footer flex items-center justify-between px-4 py-2 text-[10px]">
             {results.length > 0 ? (
               <>
                 <span>↑↓ Navigate</span>
@@ -320,7 +316,7 @@ function highlightMatch(text: string, query: string): React.ReactNode {
   const parts = text.split(new RegExp(`(${query})`, 'gi'));
   return parts.map((part, index) =>
     part.toLowerCase() === query.toLowerCase() ? (
-      <mark key={index} className="bg-[var(--accent-gold)] text-[var(--bg-primary)] px-0.5 rounded">
+      <mark key={index} className="global-search-highlight px-0.5">
         {part}
       </mark>
     ) : (


### PR DESCRIPTION
## What

Promotes the approved search style-system slice from `dev` to `main`.

## Why

Issue #40 tracks steady convergence onto Delay-in-Glass style primitives. The search page and global search dropdown were reviewed locally against deployed `main` and now use named style hooks while preserving behavior.

## Changes

- Promotes PR #81
- Moves search visual recipes into style hooks
- Keeps search behavior unchanged
- Preserves pagination cursor fix

## Testing

- PR #81 `verify` passed
- PR #81 Vercel passed
- Local side-by-side visual review against deployed `main` approved
