### PR TITLE
feat: add semantic item card link previews

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1873,11 +1873,15 @@ body {
   outline-offset: 3px;
 }
 .item-card-popover {
-  overflow: hidden;
-  border: 1px solid var(--pane-edge);
-  border-radius: 6px;
-  background: var(--ink-2);
-  box-shadow: 0 24px 60px rgb(0 0 0 / 0.45);
+  display: flex;
+  overflow: visible;
+  min-height: 96px;
+  max-height: calc(100vh - 32px);
+  flex-direction: column;
+  border: 3px double var(--pane-edge);
+  border-radius: 0;
+  background: var(--ink);
+  box-shadow: 1px 2px 8px 0 rgb(0 0 0 / 0.72);
   opacity: 0;
   pointer-events: none;
   text-align: left;
@@ -1888,6 +1892,229 @@ body {
   opacity: 1;
   pointer-events: auto;
 }
+.item-card-popover--pinned {
+  border-color: color-mix(in srgb, var(--gold-dim) 60%, var(--pane-edge) 40%);
+  box-shadow:
+    1px 2px 8px 0 rgb(0 0 0 / 0.76),
+    0 0 0 1px rgb(196 167 106 / 0.1) inset;
+}
+.item-card-popover--maximized {
+  border-radius: 0;
+}
+.item-card-popover--minimized {
+  height: 30px !important;
+  min-height: 30px;
+}
+.item-card-popover__title-bar {
+  position: relative;
+  z-index: 3;
+  display: flex;
+  height: 31px;
+  align-items: center;
+  flex: 0 0 31px;
+  border-bottom: 1px solid color-mix(in srgb, var(--gold-dim) 50%, var(--pane-edge) 50%);
+  background:
+    linear-gradient(135deg, rgb(196 167 106 / 0.12) 25%, transparent 25%) 0 0 / 8px 8px,
+    linear-gradient(135deg, transparent 75%, rgb(196 167 106 / 0.12) 75%) 0 0 / 8px 8px,
+    color-mix(in srgb, var(--ink) 88%, var(--gold-dim) 12%);
+  color: var(--gold-dim);
+  cursor: grab;
+  user-select: none;
+}
+.item-card-popover--minimized .item-card-popover__title-bar {
+  border-bottom: 0;
+  cursor: pointer;
+}
+.item-card-popframe-dragging,
+.item-card-popframe-dragging * {
+  cursor: grabbing !important;
+  user-select: none !important;
+}
+.item-card-popover__actions {
+  position: relative;
+  z-index: 4;
+  display: inline-flex;
+  height: 100%;
+  align-items: center;
+  flex: 0 0 auto;
+  padding: 0 2px;
+}
+.item-card-popover__control {
+  position: relative;
+  display: inline-flex;
+  height: 100%;
+  align-items: center;
+}
+.item-card-popover__button {
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  background: transparent;
+  color: var(--gold-dim);
+  cursor: pointer;
+  padding: 5px;
+}
+.item-card-popover__button:hover,
+.item-card-popover__button:focus-visible {
+  background: rgb(196 167 106 / 0.1);
+  color: var(--gold-bright);
+  outline: none;
+}
+.item-card-popover__button:active {
+  transform: scale(0.9);
+}
+.item-card-popover__button:disabled {
+  color: rgb(196 167 106 / 0.24);
+  cursor: default;
+}
+.item-card-popover__button svg {
+  width: 100%;
+  height: 100%;
+  filter: drop-shadow(0 0 1px var(--ink)) drop-shadow(0 0 2px var(--ink));
+  stroke-width: 2;
+}
+.item-card-popover__submenu {
+  position: absolute;
+  top: 28px;
+  left: 0;
+  display: grid;
+  visibility: hidden;
+  grid-template-columns: repeat(3, 28px);
+  gap: 1px;
+  border: 1px solid color-mix(in srgb, var(--gold-dim) 65%, var(--pane-edge) 35%);
+  background: color-mix(in srgb, var(--gold-dim) 65%, var(--pane-edge) 35%);
+  box-shadow: 1px 1px 0 0 rgb(0 0 0 / 0.6);
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    visibility 100ms ease 180ms,
+    opacity 100ms ease 180ms;
+}
+.item-card-popover__submenu::before {
+  position: absolute;
+  right: 0;
+  bottom: 100%;
+  left: 0;
+  height: 6px;
+  content: '';
+}
+.item-card-popover__control--zoom:hover .item-card-popover__submenu,
+.item-card-popover__control--open .item-card-popover__submenu,
+.item-card-popover__submenu:hover {
+  visibility: visible;
+  opacity: 1;
+  pointer-events: auto;
+}
+.item-card-popover__submenu .item-card-popover__button {
+  background: var(--ink);
+}
+.item-card-popover__title {
+  min-width: 0;
+  margin: 0;
+  overflow: hidden;
+  flex: 1 1 100%;
+  color: var(--paper);
+  filter: drop-shadow(0 0 1px var(--ink)) drop-shadow(0 0 2px var(--ink));
+  font-family: var(--font-sans);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  line-height: 1;
+  padding: 0 112px 0 12px;
+  text-align: center;
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+.item-card-popover__right-slot {
+  width: 28px;
+  height: 100%;
+  flex: 0 0 28px;
+}
+.item-card-popover__scroll {
+  min-height: 0;
+  flex: 1 1 auto;
+  overflow-y: auto;
+  background: var(--ink-2);
+  overscroll-behavior: none;
+}
+.item-card-popover__scroll::-webkit-scrollbar {
+  width: 14px;
+}
+.item-card-popover__scroll::-webkit-scrollbar-thumb {
+  box-shadow: 0 0 0 3px var(--ink-2) inset;
+  background: var(--pane-edge);
+}
+.item-card-popover__scroll::-webkit-scrollbar-thumb:hover {
+  background: var(--gold-dim);
+}
+.item-card-popover__resize {
+  position: absolute;
+  z-index: 2;
+  border: 0;
+  background: transparent;
+  padding: 0;
+}
+.item-card-popover__resize--n,
+.item-card-popover__resize--s {
+  right: 16px;
+  left: 16px;
+  height: 10px;
+  cursor: row-resize;
+}
+.item-card-popover__resize--n {
+  top: -5px;
+}
+.item-card-popover__resize--s {
+  bottom: -5px;
+}
+.item-card-popover__resize--e,
+.item-card-popover__resize--w {
+  top: 16px;
+  bottom: 16px;
+  width: 10px;
+  cursor: col-resize;
+}
+.item-card-popover__resize--e {
+  right: -5px;
+}
+.item-card-popover__resize--w {
+  left: -5px;
+}
+.item-card-popover__resize--ne,
+.item-card-popover__resize--nw,
+.item-card-popover__resize--se,
+.item-card-popover__resize--sw {
+  width: 18px;
+  height: 18px;
+}
+.item-card-popover__resize--ne,
+.item-card-popover__resize--sw {
+  cursor: nesw-resize;
+}
+.item-card-popover__resize--nw,
+.item-card-popover__resize--se {
+  cursor: nwse-resize;
+}
+.item-card-popover__resize--ne {
+  top: -6px;
+  right: -6px;
+}
+.item-card-popover__resize--nw {
+  top: -6px;
+  left: -6px;
+}
+.item-card-popover__resize--se {
+  right: -6px;
+  bottom: -6px;
+}
+.item-card-popover__resize--sw {
+  bottom: -6px;
+  left: -6px;
+}
 .item-card-status {
   padding: 16px;
   color: var(--paper-dim);
@@ -1895,8 +2122,8 @@ body {
   font-size: 14px;
 }
 .item-card-preview {
+  min-height: 100%;
   overflow: hidden;
-  border-radius: 6px;
 }
 .item-card-preview__media {
   position: relative;

--- a/components/item-cards/item-card.tsx
+++ b/components/item-cards/item-card.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import {
+  useCallback,
   useEffect,
   useLayoutEffect,
   useRef,
@@ -10,7 +11,25 @@ import {
 } from 'react';
 import { createPortal } from 'react-dom';
 import Image from 'next/image';
-import { Database, ExternalLink } from 'lucide-react';
+import {
+  ArrowDown,
+  ArrowDownLeft,
+  ArrowDownRight,
+  ArrowLeft,
+  ArrowRight,
+  ArrowUp,
+  ArrowUpLeft,
+  ArrowUpRight,
+  Copy,
+  Database,
+  ExternalLink,
+  Maximize2,
+  Minus,
+  Pin,
+  PinOff,
+  Square,
+  X,
+} from 'lucide-react';
 
 import { captureItemCardOpen } from '@/lib/analytics/browser-capture';
 import type { ItemCard as ItemCardRecord } from '@/types/item-cards';
@@ -35,10 +54,62 @@ type PreviewPosition = {
   top: number;
 };
 
-const CARD_WIDTH = 340;
-const CARD_FALLBACK_HEIGHT = 360;
+type PopFrameRect = {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+};
+
+type DragState = {
+  startX: number;
+  startY: number;
+  startRect: PopFrameRect;
+};
+
+type ResizeEdge = 'n' | 's' | 'e' | 'w' | 'ne' | 'nw' | 'se' | 'sw';
+
+type ResizeState = DragState & {
+  edge: ResizeEdge;
+};
+
+type ZoomPlace =
+  | 'top-left'
+  | 'top'
+  | 'top-right'
+  | 'left'
+  | 'full'
+  | 'right'
+  | 'bottom-left'
+  | 'bottom'
+  | 'bottom-right';
+
+const zoomButtons: Array<{
+  icon: typeof Maximize2;
+  label: string;
+  place: ZoomPlace;
+}> = [
+  { icon: ArrowUpLeft, label: 'Top-left quarter', place: 'top-left' },
+  { icon: ArrowUp, label: 'Top half', place: 'top' },
+  { icon: ArrowUpRight, label: 'Top-right quarter', place: 'top-right' },
+  { icon: ArrowLeft, label: 'Left half', place: 'left' },
+  { icon: Square, label: 'Full screen', place: 'full' },
+  { icon: ArrowRight, label: 'Right half', place: 'right' },
+  { icon: ArrowDownLeft, label: 'Bottom-left quarter', place: 'bottom-left' },
+  { icon: ArrowDown, label: 'Bottom half', place: 'bottom' },
+  { icon: ArrowDownRight, label: 'Bottom-right quarter', place: 'bottom-right' },
+];
+
+const CARD_WIDTH = 380;
+const CARD_FALLBACK_HEIGHT = 430;
+const CARD_MIN_WIDTH = 300;
+const CARD_MIN_HEIGHT = 210;
 const VIEWPORT_MARGIN = 16;
 const CURSOR_OFFSET = 14;
+const TITLE_BAR_HEIGHT = 30;
+const MINIMIZED_WIDTH = 340;
+
+let topPopFrameZIndex = 90;
 
 function isGif(url: string | undefined): boolean {
   return url?.toLowerCase().endsWith('.gif') ?? false;
@@ -64,6 +135,97 @@ function getPreviewPosition(
   };
 }
 
+function rectFromPoint(point: ViewportPoint): PopFrameRect {
+  const position = getPreviewPosition(point);
+  return {
+    left: position.left,
+    top: position.top,
+    width: Math.min(CARD_WIDTH, window.innerWidth - VIEWPORT_MARGIN * 2),
+    height: Math.min(CARD_FALLBACK_HEIGHT, window.innerHeight - VIEWPORT_MARGIN * 2),
+  };
+}
+
+function clampRect(rect: PopFrameRect): PopFrameRect {
+  const maxWidth = Math.max(CARD_MIN_WIDTH, window.innerWidth - VIEWPORT_MARGIN * 2);
+  const maxHeight = Math.max(CARD_MIN_HEIGHT, window.innerHeight - VIEWPORT_MARGIN * 2);
+  const width = Math.min(Math.max(rect.width, CARD_MIN_WIDTH), maxWidth);
+  const height = Math.min(Math.max(rect.height, CARD_MIN_HEIGHT), maxHeight);
+
+  return {
+    width,
+    height,
+    left: Math.min(
+      Math.max(rect.left, VIEWPORT_MARGIN),
+      window.innerWidth - width - VIEWPORT_MARGIN
+    ),
+    top: Math.min(
+      Math.max(rect.top, VIEWPORT_MARGIN),
+      window.innerHeight - height - VIEWPORT_MARGIN
+    ),
+  };
+}
+
+function clampPosition(rect: PopFrameRect): PopFrameRect {
+  return {
+    ...rect,
+    left: Math.min(Math.max(rect.left, 0), window.innerWidth - rect.width),
+    top: Math.min(Math.max(rect.top, 0), window.innerHeight - rect.height),
+  };
+}
+
+function minimizedRectFrom(rect: PopFrameRect): PopFrameRect {
+  return clampPosition({
+    left: 0,
+    top: window.innerHeight - TITLE_BAR_HEIGHT,
+    width: Math.min(Math.max(rect.width, MINIMIZED_WIDTH), window.innerWidth - VIEWPORT_MARGIN * 2),
+    height: TITLE_BAR_HEIGHT,
+  });
+}
+
+function maximizedRect(): PopFrameRect {
+  return {
+    left: VIEWPORT_MARGIN,
+    top: VIEWPORT_MARGIN,
+    width: window.innerWidth - VIEWPORT_MARGIN * 2,
+    height: window.innerHeight - VIEWPORT_MARGIN * 2,
+  };
+}
+
+function zoomedRect(place: ZoomPlace): PopFrameRect {
+  const left = VIEWPORT_MARGIN;
+  const top = VIEWPORT_MARGIN;
+  const width = window.innerWidth - VIEWPORT_MARGIN * 2;
+  const height = window.innerHeight - VIEWPORT_MARGIN * 2;
+  const halfWidth = width / 2;
+  const halfHeight = height / 2;
+
+  switch (place) {
+    case 'top-left':
+      return { left, top, width: halfWidth, height: halfHeight };
+    case 'top':
+      return { left, top, width, height: halfHeight };
+    case 'top-right':
+      return { left: left + halfWidth, top, width: halfWidth, height: halfHeight };
+    case 'left':
+      return { left, top, width: halfWidth, height };
+    case 'right':
+      return { left: left + halfWidth, top, width: halfWidth, height };
+    case 'bottom-left':
+      return { left, top: top + halfHeight, width: halfWidth, height: halfHeight };
+    case 'bottom':
+      return { left, top: top + halfHeight, width, height: halfHeight };
+    case 'bottom-right':
+      return {
+        left: left + halfWidth,
+        top: top + halfHeight,
+        width: halfWidth,
+        height: halfHeight,
+      };
+    case 'full':
+      return maximizedRect();
+  }
+}
+
 /**
  * Renders an explicit read-only MDX item-card reference.
  */
@@ -72,38 +234,199 @@ export function ItemCard({ id, children }: ItemCardProps) {
   const [mounted, setMounted] = useState(false);
   const [visible, setVisible] = useState(false);
   const [anchorPoint, setAnchorPoint] = useState<ViewportPoint | null>(null);
-  const [position, setPosition] = useState<PreviewPosition | null>(null);
+  const [rect, setRect] = useState<PopFrameRect | null>(null);
+  const [savedRect, setSavedRect] = useState<PopFrameRect | null>(null);
+  const [pinned, setPinned] = useState(false);
+  const [minimized, setMinimized] = useState(false);
+  const [maximized, setMaximized] = useState(false);
+  const [manuallySized, setManuallySized] = useState(false);
+  const [zoomMenuOpen, setZoomMenuOpen] = useState(false);
+  const [zIndex, setZIndex] = useState(topPopFrameZIndex);
   const [card, setCard] = useState<ItemCardRecord | null>(null);
   const [error, setError] = useState<string | null>(null);
   const closeTimerRef = useRef<number | null>(null);
+  const zoomMenuCloseTimerRef = useRef<number | null>(null);
   const previewRef = useRef<HTMLDivElement | null>(null);
+  const dragStateRef = useRef<DragState | null>(null);
+  const resizeStateRef = useRef<ResizeState | null>(null);
 
-  function clearCloseTimer() {
+  const bringToFront = useCallback(function bringToFront() {
+    topPopFrameZIndex += 1;
+    setZIndex(topPopFrameZIndex);
+  }, []);
+
+  const clearCloseTimer = useCallback(function clearCloseTimer() {
     if (closeTimerRef.current === null) {
       return;
     }
 
     window.clearTimeout(closeTimerRef.current);
     closeTimerRef.current = null;
+  }, []);
+
+  const clearZoomMenuCloseTimer = useCallback(function clearZoomMenuCloseTimer() {
+    if (zoomMenuCloseTimerRef.current === null) {
+      return;
+    }
+
+    window.clearTimeout(zoomMenuCloseTimerRef.current);
+    zoomMenuCloseTimerRef.current = null;
+  }, []);
+
+  function openZoomMenu() {
+    clearZoomMenuCloseTimer();
+    setZoomMenuOpen(true);
+  }
+
+  function scheduleZoomMenuClose() {
+    clearZoomMenuCloseTimer();
+    zoomMenuCloseTimerRef.current = window.setTimeout(() => setZoomMenuOpen(false), 220);
   }
 
   function openPreview(point: ViewportPoint) {
     clearCloseTimer();
     setAnchorPoint(point);
-    setPosition(getPreviewPosition(point));
+    setRect((currentRect) => currentRect ?? rectFromPoint(point));
+    bringToFront();
     setMounted(true);
     setOpen(true);
   }
 
+  function renderedRect(): PopFrameRect | null {
+    const viewportRect = previewRef.current?.getBoundingClientRect();
+    if (!viewportRect) {
+      return null;
+    }
+
+    return {
+      left: viewportRect.left,
+      top: viewportRect.top,
+      width: viewportRect.width,
+      height: viewportRect.height,
+    };
+  }
+
+  function restoreRect(rectToRestore: PopFrameRect | null, fallback: PopFrameRect | null) {
+    return rectToRestore ? clampRect(rectToRestore) : fallback;
+  }
+
   function closePreview() {
+    if (pinned) {
+      return;
+    }
+
     clearCloseTimer();
     setOpen(false);
   }
 
+  const closePopFrame = useCallback(
+    function closePopFrame() {
+      clearCloseTimer();
+      setOpen(false);
+      setPinned(false);
+      setMinimized(false);
+      setMaximized(false);
+      setManuallySized(false);
+      setZoomMenuOpen(false);
+    },
+    [clearCloseTimer]
+  );
+
   function scheduleClose() {
+    if (pinned) {
+      return;
+    }
+
     clearCloseTimer();
     closeTimerRef.current = window.setTimeout(closePreview, 120);
   }
+
+  const pinPopFrame = useCallback(
+    function pinPopFrame() {
+      clearCloseTimer();
+      setPinned(true);
+      bringToFront();
+    },
+    [bringToFront, clearCloseTimer]
+  );
+
+  const togglePin = useCallback(
+    function togglePin() {
+      clearCloseTimer();
+      setPinned((current) => !current);
+      bringToFront();
+    },
+    [bringToFront, clearCloseTimer]
+  );
+
+  const toggleMaximize = useCallback(
+    function toggleMaximize() {
+      pinPopFrame();
+      setMinimized(false);
+      setManuallySized(true);
+      setMaximized((currentlyMaximized) => {
+        if (currentlyMaximized) {
+          setRect((currentRect) => restoreRect(savedRect, currentRect));
+          setSavedRect(null);
+          return false;
+        }
+
+        setRect((currentRect) => {
+          const currentViewportRect = renderedRect() ?? currentRect;
+          if (currentViewportRect) {
+            setSavedRect(currentViewportRect);
+          }
+          return maximizedRect();
+        });
+        return true;
+      });
+    },
+    [pinPopFrame, savedRect]
+  );
+
+  const zoomToPlace = useCallback(
+    function zoomToPlace(place: ZoomPlace) {
+      pinPopFrame();
+      setMinimized(false);
+      setManuallySized(true);
+      setMaximized(place === 'full');
+      setRect((currentRect) => {
+        const currentViewportRect = renderedRect() ?? currentRect;
+        if (currentViewportRect && !maximized) {
+          setSavedRect(currentViewportRect);
+        }
+        return zoomedRect(place);
+      });
+    },
+    [maximized, pinPopFrame]
+  );
+
+  const toggleMinimize = useCallback(
+    function toggleMinimize() {
+      pinPopFrame();
+      setMaximized(false);
+      setManuallySized(true);
+      setMinimized((currentlyMinimized) => {
+        if (currentlyMinimized) {
+          setRect((currentRect) => restoreRect(savedRect, currentRect));
+          setSavedRect(null);
+          return false;
+        }
+
+        setRect((currentRect) => {
+          const currentViewportRect = renderedRect() ?? currentRect;
+          if (currentViewportRect) {
+            setSavedRect(currentViewportRect);
+            return minimizedRectFrom(currentViewportRect);
+          }
+
+          return currentRect;
+        });
+        return true;
+      });
+    },
+    [pinPopFrame, savedRect]
+  );
 
   useEffect(() => {
     if (!open) {
@@ -123,51 +446,200 @@ export function ItemCard({ id, children }: ItemCardProps) {
     const timer = window.setTimeout(() => {
       setMounted(false);
       setAnchorPoint(null);
-      setPosition(null);
+      setRect(null);
+      setSavedRect(null);
+      setManuallySized(false);
     }, 120);
 
     return () => window.clearTimeout(timer);
   }, [open]);
 
   useEffect(() => {
-    return clearCloseTimer;
-  }, []);
+    return () => {
+      clearCloseTimer();
+      clearZoomMenuCloseTimer();
+    };
+  }, [clearCloseTimer, clearZoomMenuCloseTimer]);
 
   useLayoutEffect(() => {
-    if (!mounted || !anchorPoint || !previewRef.current) {
+    if (!mounted || !anchorPoint || !previewRef.current || pinned) {
       return;
     }
 
     const rect = previewRef.current.getBoundingClientRect();
-    setPosition(getPreviewPosition(anchorPoint, rect.width, rect.height));
-  }, [anchorPoint, card, error, mounted]);
+    const position = getPreviewPosition(anchorPoint, rect.width, rect.height);
+    setRect((currentRect) =>
+      currentRect
+        ? { ...currentRect, left: position.left, top: position.top }
+        : {
+            left: position.left,
+            top: position.top,
+            width: Math.min(rect.width || CARD_WIDTH, window.innerWidth - VIEWPORT_MARGIN * 2),
+            height: Math.min(
+              rect.height || CARD_FALLBACK_HEIGHT,
+              window.innerHeight - VIEWPORT_MARGIN * 2
+            ),
+          }
+    );
+  }, [anchorPoint, card, error, mounted, pinned]);
 
   useEffect(() => {
-    if (!mounted || !anchorPoint) {
+    if (!mounted) {
       return;
     }
 
-    const currentAnchorPoint = anchorPoint;
-
     function reposition() {
-      const rect = previewRef.current?.getBoundingClientRect();
-      setPosition(
-        getPreviewPosition(
-          currentAnchorPoint,
-          rect?.width ?? CARD_WIDTH,
-          rect?.height ?? CARD_FALLBACK_HEIGHT
-        )
-      );
+      if (maximized) {
+        setRect(maximizedRect());
+        return;
+      }
+
+      if (minimized) {
+        setRect((currentRect) => (currentRect ? minimizedRectFrom(currentRect) : currentRect));
+        return;
+      }
+
+      setRect((currentRect) => (currentRect ? clampRect(currentRect) : currentRect));
     }
 
     window.addEventListener('resize', reposition);
-    window.addEventListener('scroll', reposition, true);
+    if (!pinned) {
+      window.addEventListener('scroll', reposition, true);
+    }
 
     return () => {
       window.removeEventListener('resize', reposition);
       window.removeEventListener('scroll', reposition, true);
     };
-  }, [anchorPoint, mounted]);
+  }, [maximized, minimized, mounted, pinned]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    function handleKeyUp(event: KeyboardEvent) {
+      if (event.metaKey || event.ctrlKey) {
+        return;
+      }
+
+      if (event.key === 'Escape') {
+        if (pinned) {
+          setPinned(false);
+          setMinimized(false);
+          setMaximized(false);
+          return;
+        }
+
+        closePopFrame();
+      }
+
+      if (!pinned) {
+        return;
+      }
+
+      if (event.key === 'q') {
+        zoomToPlace('top-left');
+      } else if (event.key === 'w') {
+        zoomToPlace('top');
+      } else if (event.key === 'e') {
+        zoomToPlace('top-right');
+      } else if (event.key === 'a') {
+        zoomToPlace('left');
+      } else if (event.key === 'd') {
+        zoomToPlace('right');
+      } else if (event.key === 'z') {
+        zoomToPlace('bottom-left');
+      } else if (event.key === 's') {
+        zoomToPlace('bottom');
+      } else if (event.key === 'x') {
+        zoomToPlace('bottom-right');
+      } else if (event.key === 'f') {
+        toggleMaximize();
+      } else if (event.key === 't') {
+        toggleMinimize();
+      } else if (event.key === 'c') {
+        togglePin();
+      } else if (event.key === 'r' && (maximized || minimized)) {
+        setRect((currentRect) => restoreRect(savedRect, currentRect));
+        setSavedRect(null);
+        setManuallySized(false);
+        setMaximized(false);
+        setMinimized(false);
+      }
+    }
+
+    document.addEventListener('keyup', handleKeyUp);
+    return () => document.removeEventListener('keyup', handleKeyUp);
+  }, [
+    closePopFrame,
+    maximized,
+    minimized,
+    open,
+    pinned,
+    savedRect,
+    toggleMaximize,
+    toggleMinimize,
+    togglePin,
+    zoomToPlace,
+  ]);
+
+  useEffect(() => {
+    function handlePointerMove(event: PointerEvent) {
+      const dragState = dragStateRef.current;
+      if (dragState) {
+        const nextRect = clampRect({
+          ...dragState.startRect,
+          left: dragState.startRect.left + event.clientX - dragState.startX,
+          top: dragState.startRect.top + event.clientY - dragState.startY,
+        });
+        setRect(nextRect);
+        return;
+      }
+
+      const resizeState = resizeStateRef.current;
+      if (!resizeState) {
+        return;
+      }
+
+      const deltaX = event.clientX - resizeState.startX;
+      const deltaY = event.clientY - resizeState.startY;
+      const nextRect = { ...resizeState.startRect };
+
+      if (resizeState.edge.includes('e')) {
+        nextRect.width = resizeState.startRect.width + deltaX;
+      }
+      if (resizeState.edge.includes('s')) {
+        nextRect.height = resizeState.startRect.height + deltaY;
+      }
+      if (resizeState.edge.includes('w')) {
+        nextRect.left = resizeState.startRect.left + deltaX;
+        nextRect.width = resizeState.startRect.width - deltaX;
+      }
+      if (resizeState.edge.includes('n')) {
+        nextRect.top = resizeState.startRect.top + deltaY;
+        nextRect.height = resizeState.startRect.height - deltaY;
+      }
+
+      setRect(clampRect(nextRect));
+    }
+
+    function handlePointerUp() {
+      dragStateRef.current = null;
+      resizeStateRef.current = null;
+      document.documentElement.classList.remove('item-card-popframe-dragging');
+    }
+
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', handlePointerUp);
+    window.addEventListener('pointercancel', handlePointerUp);
+
+    return () => {
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', handlePointerUp);
+      window.removeEventListener('pointercancel', handlePointerUp);
+    };
+  }, []);
 
   useEffect(() => {
     if (!open || card || error) {
@@ -211,7 +683,7 @@ export function ItemCard({ id, children }: ItemCardProps) {
     event.preventDefault();
 
     if (open) {
-      closePreview();
+      pinPopFrame();
       return;
     }
 
@@ -223,6 +695,46 @@ export function ItemCard({ id, children }: ItemCardProps) {
       source: 'mdx_inline',
     });
     openPreview({ x: event.clientX, y: event.clientY });
+    setPinned(true);
+  }
+
+  function startDrag(event: MouseEvent<HTMLDivElement>) {
+    if (!rect || minimized || event.button !== 0) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    pinPopFrame();
+    setMaximized(false);
+    dragStateRef.current = {
+      startX: event.clientX,
+      startY: event.clientY,
+      startRect: savedRect ?? rect,
+    };
+    if (maximized && savedRect) {
+      setRect(savedRect);
+      setSavedRect(null);
+    }
+    document.documentElement.classList.add('item-card-popframe-dragging');
+  }
+
+  function startResize(edge: ResizeEdge, event: MouseEvent<HTMLButtonElement>) {
+    if (!rect || !pinned || minimized || maximized || event.button !== 0) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    bringToFront();
+    setManuallySized(true);
+    resizeStateRef.current = {
+      edge,
+      startX: event.clientX,
+      startY: event.clientY,
+      startRect: previewRef.current?.getBoundingClientRect() ?? rect,
+    };
+    document.documentElement.classList.add('item-card-popframe-dragging');
   }
 
   return (
@@ -242,26 +754,106 @@ export function ItemCard({ id, children }: ItemCardProps) {
         {children}
       </button>
       {mounted &&
-        position &&
+        rect &&
         createPortal(
           <div
             ref={previewRef}
-            aria-hidden={!open}
+            role={pinned ? 'dialog' : 'tooltip'}
+            aria-hidden={!open ? true : undefined}
+            aria-label={card ? `${card.title} item card popframe` : 'Item card popframe'}
             inert={!open}
-            className={`item-card-popover fixed z-[90] w-[min(340px,calc(100vw-32px))] ${
+            className={`item-card-popover fixed ${
               visible ? 'item-card-popover--visible' : ''
-            }`}
+            } ${pinned ? 'item-card-popover--pinned' : ''} ${
+              minimized ? 'item-card-popover--minimized' : ''
+            } ${maximized ? 'item-card-popover--maximized' : ''}`}
             style={{
-              left: position.left,
-              top: position.top,
+              left: rect.left,
+              top: rect.top,
+              width: rect.width,
+              height: manuallySized ? rect.height : undefined,
+              zIndex,
             }}
             onMouseEnter={clearCloseTimer}
             onMouseLeave={scheduleClose}
+            onMouseDown={bringToFront}
           >
-            {card ? (
-              <ItemCardPreview card={card} />
-            ) : (
-              <ItemCardStatus message={error ?? 'Loading...'} />
+            <div className="item-card-popover__title-bar" onMouseDown={startDrag}>
+              <div className="item-card-popover__actions" aria-label="Item card popframe controls">
+                <TitleBarButton label="Close item card popframe" onClick={closePopFrame}>
+                  <X />
+                </TitleBarButton>
+                <div
+                  className={`item-card-popover__control item-card-popover__control--zoom ${
+                    zoomMenuOpen ? 'item-card-popover__control--open' : ''
+                  }`}
+                  onMouseEnter={openZoomMenu}
+                  onMouseLeave={scheduleZoomMenuClose}
+                  onFocus={openZoomMenu}
+                  onBlur={scheduleZoomMenuClose}
+                >
+                  <TitleBarButton
+                    label={maximized ? 'Restore item card popframe' : 'Maximize item card popframe'}
+                    onClick={toggleMaximize}
+                    disabled={minimized}
+                  >
+                    {maximized ? <Copy /> : <Square />}
+                  </TitleBarButton>
+                  <div
+                    className="item-card-popover__submenu"
+                    aria-label="Zoom item card popframe"
+                    onMouseEnter={openZoomMenu}
+                    onMouseLeave={scheduleZoomMenuClose}
+                  >
+                    {zoomButtons.map(({ icon: Icon, label, place }) => (
+                      <TitleBarButton key={place} label={label} onClick={() => zoomToPlace(place)}>
+                        <Icon />
+                      </TitleBarButton>
+                    ))}
+                  </div>
+                </div>
+                <TitleBarButton
+                  label={
+                    minimized ? 'Unminimize item card popframe' : 'Minimize item card popframe'
+                  }
+                  onClick={toggleMinimize}
+                >
+                  {minimized ? <Square /> : <Minus />}
+                </TitleBarButton>
+                <TitleBarButton
+                  label={pinned ? 'Unpin item card popframe' : 'Pin item card popframe'}
+                  onClick={togglePin}
+                  disabled={minimized}
+                >
+                  {pinned ? <PinOff /> : <Pin />}
+                </TitleBarButton>
+              </div>
+              <p className="item-card-popover__title">{card?.title ?? children}</p>
+              <div className="item-card-popover__right-slot" aria-hidden="true" />
+            </div>
+
+            {!minimized && (
+              <div className="item-card-popover__scroll">
+                {card ? (
+                  <ItemCardPreview card={card} />
+                ) : (
+                  <ItemCardStatus message={error ?? 'Loading...'} />
+                )}
+              </div>
+            )}
+
+            {pinned && !minimized && !maximized && (
+              <>
+                {(['n', 's', 'e', 'w', 'ne', 'nw', 'se', 'sw'] as const).map((edge) => (
+                  <button
+                    key={edge}
+                    type="button"
+                    aria-label={`Resize item card popframe ${edge}`}
+                    className={`item-card-popover__resize item-card-popover__resize--${edge}`}
+                    onMouseDown={(event) => startResize(edge, event)}
+                  />
+                ))}
+              </>
             )}
           </div>,
           document.body
@@ -274,9 +866,41 @@ function ItemCardStatus({ message }: { message: string }) {
   return <div className="item-card-status">{message}</div>;
 }
 
+function TitleBarButton({
+  children,
+  disabled,
+  label,
+  onClick,
+}: {
+  children: ReactNode;
+  disabled?: boolean;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className="item-card-popover__button"
+      aria-label={label}
+      title={label}
+      disabled={disabled}
+      onClick={(event) => {
+        event.stopPropagation();
+        onClick();
+      }}
+      onMouseDown={(event) => event.stopPropagation()}
+    >
+      {children}
+    </button>
+  );
+}
+
 function ItemCardPreview({ card }: { card: ItemCardRecord }) {
   const image = card.image ?? card.images?.[0];
   const [imageFailed, setImageFailed] = useState(false);
+  const classification = [card.section, card.category, card.subcategory]
+    .filter(Boolean)
+    .join(' / ');
 
   useEffect(() => {
     setImageFailed(false);
@@ -311,14 +935,12 @@ function ItemCardPreview({ card }: { card: ItemCardRecord }) {
       <div className="item-card-preview__body">
         <div className="item-card-preview__header">
           <p className="item-card-preview__title">{card.title}</p>
-          {(card.category || card.subcategory) && (
-            <p className="item-card-preview__meta">
-              {[card.category, card.subcategory].filter(Boolean).join(' - ')}
-            </p>
-          )}
+          {classification && <p className="item-card-preview__meta">{classification}</p>}
         </div>
 
-        <p className="item-card-preview__description line-clamp-4">{card.description}</p>
+        <p className="item-card-preview__description">
+          {card.description ?? 'No description has been recorded for this card yet.'}
+        </p>
 
         <div className="item-card-preview__actions">
           <a


### PR DESCRIPTION
## Summary

Separates the functional improvement that was previously mixed into the Issue #51 cleanup branch.

- adds semantic item-card link previews for rendered MDX links
- resolves item-card links to local item-card data
- supports hover/focus previews, click pinning, close/Escape dismissal, and viewport-aware positioning
- keeps the preview styling Elden Glass-native rather than copying Gwern's visual design

This intentionally does not include the Issue #51 item-card corpus cleanup. That data/text cleanup is split into its own PR.

## Validation

- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `NEXT_TELEMETRY_DISABLED=1 npm run build`
