### PR TITLE
refactor: dry app-route style recipes

### DIFF
--- a/app/(site)/gatherer/page.tsx
+++ b/app/(site)/gatherer/page.tsx
@@ -292,12 +292,12 @@ function GathererContent() {
   );
 
   return (
-    <div className="min-h-screen bg-[var(--bg-primary)]">
+    <div className="min-h-screen">
       {/* Header */}
-      <div className="border-b border-[var(--border-subtle)] bg-[var(--bg-secondary)] px-6 py-8">
+      <div className="dig-page-band px-6 py-8">
         <div className="max-w-7xl mx-auto">
-          <h1 className="text-4xl font-serif text-[var(--accent-gold)] mb-2">Item Cards</h1>
-          <p className="text-[var(--text-secondary)]">
+          <h1 className="dig-page-title mb-2 text-4xl">Item Cards</h1>
+          <p className="dig-muted">
             Browse and search {data?.total?.toLocaleString() || '...'} structured item cards
           </p>
           {SHOW_LOCAL_FEDWIKI_LINK && (
@@ -305,7 +305,7 @@ function GathererContent() {
               href="http://localhost:3000/assets/gatherer.html"
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 mt-3 text-sm text-[var(--accent-gold)] hover:underline"
+              className="dig-link mt-3 inline-flex items-center gap-2 text-sm"
             >
               <Globe className="h-4 w-4" />
               Open local Federated Wiki export
@@ -318,18 +318,18 @@ function GathererContent() {
         {/* Search and Filter Toggle */}
         <div className="flex flex-col sm:flex-row gap-4 mb-6">
           <div className="relative flex-1">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 text-[var(--text-tertiary)]" />
+            <Search className="dig-muted absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2" />
             <input
               type="text"
               placeholder="Search cards by name, term, or description..."
               value={searchInput}
               onChange={(e) => setSearchInput(e.target.value)}
-              className="w-full pl-10 pr-4 py-3 bg-[var(--bg-secondary)] border border-[var(--border-subtle)] rounded-lg text-[var(--text-primary)] placeholder:text-[var(--text-tertiary)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-gold)] focus:border-transparent"
+              className="dig-input dig-input--subtle w-full py-3 pl-10 pr-4 focus:outline-none"
             />
             {searchInput && (
               <button
                 onClick={() => setSearchInput('')}
-                className="absolute right-3 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)] hover:text-[var(--text-primary)]"
+                className="dig-icon-button absolute right-3 top-1/2 -translate-y-1/2"
               >
                 <X className="h-5 w-5" />
               </button>
@@ -337,10 +337,8 @@ function GathererContent() {
           </div>
           <button
             onClick={() => setShowFilters(!showFilters)}
-            className={`flex items-center gap-2 px-4 py-3 rounded-lg border transition ${
-              showFilters || hasActiveFilters
-                ? 'bg-[var(--accent-gold)]/10 border-[var(--accent-gold)] text-[var(--accent-gold)]'
-                : 'bg-[var(--bg-secondary)] border-[var(--border-subtle)] text-[var(--text-secondary)] hover:text-[var(--text-primary)]'
+            className={`dig-control-button flex items-center gap-2 px-4 py-3 ${
+              showFilters || hasActiveFilters ? 'is-active' : ''
             }`}
           >
             <Filter className="h-5 w-5" />
@@ -351,17 +349,17 @@ function GathererContent() {
 
         {/* Filters */}
         {showFilters && (
-          <div className="mb-6 rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-secondary)] p-3 sm:p-4">
+          <div className="dig-control-panel mb-6 p-3 sm:p-4">
             <div className="grid grid-cols-2 gap-3 lg:grid-cols-4 lg:gap-4">
               {/* Section Filter */}
               <div>
-                <label className="mb-1 block text-[0.65rem] uppercase tracking-wider text-[var(--text-tertiary)] sm:mb-2 sm:text-xs">
+                <label className="dig-muted mb-1 block text-[0.65rem] uppercase tracking-wider sm:mb-2 sm:text-xs">
                   Section
                 </label>
                 <select
                   value={urlSection}
                   onChange={(e) => handleSectionChange(e.target.value)}
-                  className="w-full rounded border border-[var(--border-subtle)] bg-[var(--bg-primary)] px-2 py-1.5 text-sm text-[var(--text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-gold)] sm:rounded-lg sm:px-3 sm:py-2"
+                  className="dig-select w-full rounded px-2 py-1.5 text-sm focus:outline-none sm:rounded-lg sm:px-3 sm:py-2"
                 >
                   <option value="">All Sections</option>
                   {data?.sections?.map((section) => (
@@ -374,13 +372,13 @@ function GathererContent() {
 
               {/* Category Filter */}
               <div>
-                <label className="mb-1 block text-[0.65rem] uppercase tracking-wider text-[var(--text-tertiary)] sm:mb-2 sm:text-xs">
+                <label className="dig-muted mb-1 block text-[0.65rem] uppercase tracking-wider sm:mb-2 sm:text-xs">
                   Category
                 </label>
                 <select
                   value={urlCategory}
                   onChange={(e) => handleCategoryChange(e.target.value)}
-                  className="w-full rounded border border-[var(--border-subtle)] bg-[var(--bg-primary)] px-2 py-1.5 text-sm text-[var(--text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-gold)] sm:rounded-lg sm:px-3 sm:py-2"
+                  className="dig-select w-full rounded px-2 py-1.5 text-sm focus:outline-none sm:rounded-lg sm:px-3 sm:py-2"
                 >
                   <option value="">All Categories</option>
                   {data?.categories?.map((category) => (
@@ -393,13 +391,13 @@ function GathererContent() {
 
               {/* Subcategory Filter */}
               <div>
-                <label className="mb-1 block text-[0.65rem] uppercase tracking-wider text-[var(--text-tertiary)] sm:mb-2 sm:text-xs">
+                <label className="dig-muted mb-1 block text-[0.65rem] uppercase tracking-wider sm:mb-2 sm:text-xs">
                   Subcategory
                 </label>
                 <select
                   value={urlSubcategory}
                   onChange={(e) => handleSubcategoryChange(e.target.value)}
-                  className="w-full rounded border border-[var(--border-subtle)] bg-[var(--bg-primary)] px-2 py-1.5 text-sm text-[var(--text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-gold)] sm:rounded-lg sm:px-3 sm:py-2"
+                  className="dig-select w-full rounded px-2 py-1.5 text-sm focus:outline-none sm:rounded-lg sm:px-3 sm:py-2"
                 >
                   <option value="">All Subcategories</option>
                   {data?.subcategories?.map((subcategory) => (
@@ -412,13 +410,13 @@ function GathererContent() {
 
               {/* Source Filter */}
               <div>
-                <label className="mb-1 block text-[0.65rem] uppercase tracking-wider text-[var(--text-tertiary)] sm:mb-2 sm:text-xs">
+                <label className="dig-muted mb-1 block text-[0.65rem] uppercase tracking-wider sm:mb-2 sm:text-xs">
                   Source
                 </label>
                 <select
                   value={urlSource}
                   onChange={(e) => handleSourceChange(e.target.value)}
-                  className="w-full rounded border border-[var(--border-subtle)] bg-[var(--bg-primary)] px-2 py-1.5 text-sm text-[var(--text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-gold)] sm:rounded-lg sm:px-3 sm:py-2"
+                  className="dig-select w-full rounded px-2 py-1.5 text-sm focus:outline-none sm:rounded-lg sm:px-3 sm:py-2"
                 >
                   <option value="">All Sources</option>
                   <option value="base">Base Game</option>
@@ -430,8 +428,8 @@ function GathererContent() {
 
             {/* Quick Section Filters */}
             {data?.sections && data.sections.length > 0 && (
-              <div className="mt-3 border-t border-[var(--border-subtle)] pt-3 sm:mt-4 sm:pt-4">
-                <label className="mb-2 block text-[0.65rem] uppercase tracking-wider text-[var(--text-tertiary)] sm:text-xs">
+              <div className="mt-3 border-t border-[var(--pane-edge)] pt-3 sm:mt-4 sm:pt-4">
+                <label className="dig-muted mb-2 block text-[0.65rem] uppercase tracking-wider sm:text-xs">
                   Quick Filters
                 </label>
                 <div className="-mx-3 flex max-h-11 gap-2 overflow-x-auto px-3 pb-1 sm:mx-0 sm:max-h-none sm:flex-wrap sm:overflow-visible sm:px-0 sm:pb-0">
@@ -439,10 +437,8 @@ function GathererContent() {
                     <button
                       key={section}
                       onClick={() => handleSectionChange(section === urlSection ? '' : section)}
-                      className={`shrink-0 rounded-full px-3 py-1 text-xs transition sm:py-1.5 sm:text-sm ${
-                        urlSection === section
-                          ? 'bg-[var(--accent-gold)] text-black'
-                          : 'bg-[var(--bg-primary)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] border border-[var(--border-subtle)]'
+                      className={`dig-filter-chip shrink-0 px-3 py-1 text-xs sm:py-1.5 sm:text-sm ${
+                        urlSection === section ? 'is-active' : ''
                       }`}
                     >
                       {section}
@@ -453,16 +449,13 @@ function GathererContent() {
             )}
 
             {hasActiveFilters && (
-              <div className="mt-4 pt-4 border-t border-[var(--border-subtle)] flex items-center justify-between">
-                <span className="text-sm text-[var(--text-secondary)]">
+              <div className="mt-4 flex items-center justify-between border-t border-[var(--pane-edge)] pt-4">
+                <span className="dig-muted text-sm">
                   {data
                     ? `Showing ${data.cards.length} of ${data.total.toLocaleString()} matching cards`
                     : 'Loading...'}
                 </span>
-                <button
-                  onClick={clearFilters}
-                  className="text-sm text-[var(--accent-gold)] hover:underline"
-                >
+                <button onClick={clearFilters} className="dig-link text-sm">
                   Clear all filters
                 </button>
               </div>
@@ -473,11 +466,8 @@ function GathererContent() {
         {/* Error State */}
         {error && (
           <div className="text-center py-20">
-            <p className="text-red-500 mb-4">{error}</p>
-            <button
-              onClick={() => window.location.reload()}
-              className="text-[var(--accent-gold)] hover:underline"
-            >
+            <p className="dig-error mb-4">{error}</p>
+            <button onClick={() => window.location.reload()} className="dig-link">
               Try again
             </button>
           </div>
@@ -497,7 +487,7 @@ function GathererContent() {
           <>
             {/* Results Header with Pagination */}
             <div className="flex items-center justify-between mb-4">
-              <div className="text-sm text-[var(--text-secondary)]">
+              <div className="dig-muted text-sm">
                 {loading ? (
                   <span className="animate-pulse">Loading...</span>
                 ) : (
@@ -540,12 +530,9 @@ function GathererContent() {
             {/* No Results */}
             {data.cards.length === 0 && !loading && (
               <div className="text-center py-20">
-                <Database className="h-16 w-16 text-[var(--accent-gold)]/30 mx-auto mb-6" />
-                <p className="text-[var(--text-secondary)] mb-4">No cards match your filters</p>
-                <button
-                  onClick={clearFilters}
-                  className="text-[var(--accent-gold)] hover:underline"
-                >
+                <Database className="dig-link mx-auto mb-6 h-16 w-16 opacity-30" />
+                <p className="dig-muted mb-4">No cards match your filters</p>
+                <button onClick={clearFilters} className="dig-link">
                   Clear all filters
                 </button>
               </div>
@@ -571,15 +558,15 @@ function GathererContent() {
 // Full page skeleton for Suspense fallback
 function GathererSkeleton() {
   return (
-    <div className="min-h-screen bg-[var(--bg-primary)]">
-      <div className="border-b border-[var(--border-subtle)] bg-[var(--bg-secondary)] px-6 py-8">
+    <div className="min-h-screen">
+      <div className="dig-page-band px-6 py-8">
         <div className="max-w-7xl mx-auto">
-          <div className="h-10 w-48 bg-[var(--bg-primary)] rounded animate-pulse mb-2" />
-          <div className="h-5 w-72 bg-[var(--bg-primary)] rounded animate-pulse" />
+          <div className="dig-skeleton mb-2 h-10 w-48 animate-pulse" />
+          <div className="dig-skeleton h-5 w-72 animate-pulse" />
         </div>
       </div>
       <div className="max-w-7xl mx-auto px-6 py-6">
-        <div className="h-12 w-full bg-[var(--bg-secondary)] rounded-lg animate-pulse mb-6" />
+        <div className="dig-skeleton mb-6 h-12 w-full animate-pulse" />
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
           {Array.from({ length: 12 }).map((_, i) => (
             <CardSkeleton key={i} />
@@ -709,7 +696,7 @@ function Pagination({
       <button
         onClick={() => onPageChange(currentPage - 1)}
         disabled={currentPage === 1}
-        className="p-2 rounded hover:bg-[var(--bg-secondary)] disabled:opacity-30 disabled:cursor-not-allowed transition"
+        className="dig-page-button p-2 disabled:opacity-30"
         aria-label="Previous page"
       >
         <ChevronLeft className="h-4 w-4" />
@@ -717,17 +704,15 @@ function Pagination({
 
       {getPageNumbers().map((page, i) =>
         page === '...' ? (
-          <span key={`ellipsis-${i}`} className="px-2 text-[var(--text-tertiary)]">
+          <span key={`ellipsis-${i}`} className="dig-muted px-2">
             ...
           </span>
         ) : (
           <button
             key={page}
             onClick={() => onPageChange(page as number)}
-            className={`min-w-[36px] h-9 rounded text-sm font-medium transition ${
-              currentPage === page
-                ? 'bg-[var(--accent-gold)] text-black'
-                : 'hover:bg-[var(--bg-secondary)] text-[var(--text-secondary)]'
+            className={`dig-page-button dig-page-button--solid-active h-9 min-w-[36px] text-sm font-medium ${
+              currentPage === page ? 'is-active' : ''
             }`}
           >
             {page}
@@ -738,7 +723,7 @@ function Pagination({
       <button
         onClick={() => onPageChange(currentPage + 1)}
         disabled={currentPage === totalPages}
-        className="p-2 rounded hover:bg-[var(--bg-secondary)] disabled:opacity-30 disabled:cursor-not-allowed transition"
+        className="dig-page-button p-2 disabled:opacity-30"
         aria-label="Next page"
       >
         <ChevronRight className="h-4 w-4" />

--- a/app/(site)/search/page.tsx
+++ b/app/(site)/search/page.tsx
@@ -125,35 +125,35 @@ function SearchContent() {
   return (
     <div className="min-h-screen">
       {/* Header */}
-      <div className="search-page-header px-6 py-8">
+      <div className="dig-page-band px-6 py-8">
         <div className="max-w-4xl mx-auto">
-          <h1 className="search-page-title mb-4">Search</h1>
+          <h1 className="dig-page-title mb-4">Search</h1>
 
           {/* Search Input */}
           <form onSubmit={handleSubmit} className="relative">
-            <Search className="search-page-input-icon absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2" />
+            <Search className="dig-muted absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2" />
             <input
               type="text"
               value={searchInput}
               onChange={(e) => setSearchInput(e.target.value)}
               placeholder="Search the site..."
               autoFocus
-              className="search-page-input w-full py-4 pl-12 pr-12 text-lg focus:outline-none"
+              className="dig-input w-full py-4 pl-12 pr-12 text-lg focus:outline-none"
             />
             {searchInput && (
               <button
                 type="button"
                 onClick={handleClear}
-                className="search-page-clear absolute right-4 top-1/2 -translate-y-1/2"
+                className="dig-icon-button absolute right-4 top-1/2 -translate-y-1/2"
               >
                 <X className="h-5 w-5" />
               </button>
             )}
           </form>
 
-          <p className="search-page-note mt-3 text-sm">
+          <p className="dig-muted mt-3 text-sm">
             Search through all documents and pages. For item cards, use{' '}
-            <Link href="/gatherer" className="search-page-link">
+            <Link href="/gatherer" className="dig-link">
               Item Cards
             </Link>
             .
@@ -175,7 +175,7 @@ function SearchContent() {
         {/* Results List */}
         {!loading && results.length > 0 && (
           <div className="space-y-1">
-            <p className="search-page-count mb-6 text-sm">
+            <p className="dig-muted mb-6 text-sm">
               Showing {(urlPage - 1) * 20 + 1}-{Math.min(urlPage * 20, total)} of {total} result
               {total !== 1 ? 's' : ''} for &quot;{urlQuery}&quot;
             </p>
@@ -202,23 +202,17 @@ function SearchContent() {
         {/* No Results */}
         {!loading && urlQuery && results.length === 0 && (
           <div className="text-center py-16">
-            <FileText className="search-page-empty-icon mx-auto mb-4 h-12 w-12" />
-            <p className="search-page-empty-title mb-2">
-              No results found for &quot;{urlQuery}&quot;
-            </p>
-            <p className="search-page-empty-copy text-sm">
-              Try different keywords or check your spelling
-            </p>
+            <FileText className="dig-muted mx-auto mb-4 h-12 w-12" />
+            <p className="dig-copy mb-2">No results found for &quot;{urlQuery}&quot;</p>
+            <p className="dig-muted text-sm">Try different keywords or check your spelling</p>
           </div>
         )}
 
         {/* Initial State */}
         {!loading && !urlQuery && (
           <div className="text-center py-16">
-            <Search className="search-page-empty-icon mx-auto mb-4 h-12 w-12" />
-            <p className="search-page-empty-title">
-              Enter a search term to find content across the site
-            </p>
+            <Search className="dig-muted mx-auto mb-4 h-12 w-12" />
+            <p className="dig-copy">Enter a search term to find content across the site</p>
           </div>
         )}
       </div>
@@ -248,20 +242,20 @@ const SearchResultItem = memo(function SearchResultItem({
           resultType: 'content',
         })
       }
-      className="search-result-item group -mx-4 block p-4"
+      className="dig-hover-row group -mx-4 block p-4"
     >
       {/* Page Title */}
       <div className="flex items-center gap-2 mb-2">
-        <FileText className="search-result-icon h-4 w-4" />
-        <span className="search-result-page text-sm font-medium">{result.pageTitle}</span>
-        <ArrowRight className="search-result-arrow h-3 w-3 opacity-0 transition group-hover:opacity-100" />
+        <FileText className="dig-link h-4 w-4" />
+        <span className="dig-link text-sm font-medium">{result.pageTitle}</span>
+        <ArrowRight className="dig-muted h-3 w-3 opacity-0 transition group-hover:opacity-100" />
       </div>
 
       {/* Matched Sentence */}
-      <p className="search-result-sentence mb-1">{highlightMatch(result.sentence, query)}</p>
+      <p className="dig-copy mb-1">{highlightMatch(result.sentence, query)}</p>
 
       {/* Context */}
-      <p className="search-result-context line-clamp-2 text-sm">{result.context}</p>
+      <p className="dig-muted line-clamp-2 text-sm">{result.context}</p>
     </Link>
   );
 });
@@ -314,25 +308,25 @@ const Pagination = memo(function Pagination({
   };
 
   return (
-    <div className="search-pagination mt-8 flex items-center justify-center gap-2 pt-6">
+    <div className="dig-pagination mt-8 flex items-center justify-center gap-2 pt-6">
       <button
         onClick={() => onPageChange(currentPage - 1)}
         disabled={currentPage === 1}
-        className="search-pagination-arrow p-2"
+        className="dig-page-button p-2"
       >
         <ChevronLeft className="h-4 w-4" />
       </button>
 
       {getPageNumbers().map((page, index) =>
         page === 'ellipsis' ? (
-          <span key={`ellipsis-${index}`} className="search-pagination-ellipsis px-2">
+          <span key={`ellipsis-${index}`} className="dig-muted px-2">
             ...
           </span>
         ) : (
           <button
             key={page}
             onClick={() => onPageChange(page)}
-            className={`search-pagination-page h-10 min-w-[40px] ${
+            className={`dig-page-button h-10 min-w-[40px] ${
               page === currentPage ? 'is-active' : ''
             }`}
           >
@@ -344,7 +338,7 @@ const Pagination = memo(function Pagination({
       <button
         onClick={() => onPageChange(currentPage + 1)}
         disabled={currentPage === totalPages}
-        className="search-pagination-arrow p-2"
+        className="dig-page-button p-2"
       >
         <ChevronRight className="h-4 w-4" />
       </button>
@@ -358,7 +352,7 @@ function highlightMatch(text: string, query: string): React.ReactNode {
   const parts = text.split(new RegExp(`(${escapeRegex(query)})`, 'gi'));
   return parts.map((part, index) =>
     part.toLowerCase() === query.toLowerCase() ? (
-      <mark key={index} className="search-highlight px-0.5">
+      <mark key={index} className="dig-highlight px-0.5">
         {part}
       </mark>
     ) : (
@@ -374,10 +368,10 @@ function escapeRegex(string: string) {
 function SearchSkeleton() {
   return (
     <div className="min-h-screen">
-      <div className="search-page-header px-6 py-8">
+      <div className="dig-page-band px-6 py-8">
         <div className="max-w-4xl mx-auto">
-          <div className="search-skeleton mb-4 h-9 w-32 animate-pulse" />
-          <div className="search-skeleton h-14 w-full animate-pulse" />
+          <div className="dig-skeleton mb-4 h-9 w-32 animate-pulse" />
+          <div className="dig-skeleton h-14 w-full animate-pulse" />
         </div>
       </div>
       <div className="max-w-4xl mx-auto px-6 py-8">
@@ -394,9 +388,9 @@ function SearchSkeleton() {
 function ResultSkeleton() {
   return (
     <div className="p-4 animate-pulse">
-      <div className="search-skeleton mb-3 h-4 w-32" />
-      <div className="search-skeleton mb-2 h-5 w-full" />
-      <div className="search-skeleton h-4 w-3/4" />
+      <div className="dig-skeleton mb-3 h-4 w-32" />
+      <div className="dig-skeleton mb-2 h-5 w-full" />
+      <div className="dig-skeleton h-4 w-3/4" />
     </div>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -78,6 +78,7 @@
   --rule: 1px solid var(--crack);
   --rule-strong: 1px solid var(--crack-strong);
   --rule-gold: 1px solid var(--gold-dim);
+  --shadow-panel: 0 20px 50px rgb(0 0 0 / 0.35);
 
   /* ────────────────────────────────────────────────────────────
      Legacy token aliases — keep existing components painting the
@@ -1658,49 +1659,45 @@ body {
   text-transform: uppercase;
 }
 
-/* Search surfaces — shared page and global-search composition over Delay
-   tokens. These classes intentionally replace older legacy-token Tailwind
-   recipes without changing the search interaction model. */
-.search-page-header {
+/* Delay interface recipes — reusable control, list, and feedback surfaces
+   for bespoke app routes. Layout stays in Tailwind; visual identity lives
+   here so feature routes do not grow parallel CSS dialects. */
+.dig-page-band {
   border-bottom: 1px solid var(--pane-edge);
   background: var(--ink-2);
 }
-.search-page-title {
+.dig-page-title {
   color: var(--gold);
   font-family: var(--font-serif);
   font-size: 30px;
   line-height: 1.2;
 }
-.search-page-input-icon,
-.search-page-clear,
-.search-page-note,
-.search-page-count,
-.search-result-arrow,
-.search-result-context,
-.search-pagination-ellipsis,
-.search-page-empty-icon,
-.global-search-icon-button,
-.global-search-clear,
-.global-search-empty,
-.global-search-result-meta,
-.global-search-result-context,
-.global-search-footer {
+.dig-muted {
   color: var(--paper-dimmer);
 }
-.search-page-clear,
-.global-search-icon-button,
-.global-search-clear {
-  transition: color 0.15s ease;
-}
-.search-page-clear:hover,
-.global-search-clear:hover {
+.dig-copy {
   color: var(--paper);
 }
-.global-search-icon-button:hover {
+.dig-link {
   color: var(--gold);
 }
-.search-page-input,
-.global-search-input {
+.dig-link:hover {
+  text-decoration: underline;
+}
+.dig-error {
+  color: var(--rust);
+}
+.dig-icon-button {
+  color: var(--paper-dimmer);
+  transition: color 0.15s ease;
+}
+.dig-icon-button:hover {
+  color: var(--paper);
+}
+.dig-icon-button--accent:hover {
+  color: var(--gold);
+}
+.dig-input {
   border: 1px solid var(--pane-edge);
   border-radius: 8px;
   background: var(--ink);
@@ -1709,47 +1706,74 @@ body {
     border-color 0.15s ease,
     box-shadow 0.15s ease;
 }
-.search-page-input::placeholder,
-.global-search-input::placeholder {
+.dig-input::placeholder {
   color: var(--paper-dimmer);
 }
-.search-page-input:focus,
-.global-search-input:focus {
+.dig-input:focus {
   border-color: transparent;
   box-shadow: 0 0 0 2px var(--gold);
 }
-.global-search-input {
+.dig-input--subtle {
   background: color-mix(in srgb, var(--ink-2) 50%, transparent);
 }
-.search-page-link,
-.search-result-icon,
-.search-result-page,
-.global-search-result-page {
-  color: var(--gold);
-}
-.search-page-link:hover {
-  text-decoration: underline;
-}
-.search-page-empty-title,
-.search-result-sentence,
-.global-search-result-sentence {
+.dig-select {
+  border: 1px solid var(--pane-edge);
+  background: var(--ink);
   color: var(--paper);
 }
-.search-page-empty-copy {
-  color: var(--paper-dimmer);
+.dig-select:focus {
+  border-color: transparent;
+  box-shadow: 0 0 0 2px var(--gold);
 }
-.search-result-item {
+.dig-control-button {
+  border: 1px solid var(--pane-edge);
+  border-radius: 8px;
+  background: var(--ink-2);
+  color: var(--paper-dim);
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease;
+}
+.dig-control-button:hover {
+  color: var(--paper);
+}
+.dig-control-button.is-active {
+  border-color: var(--gold);
+  background: color-mix(in srgb, var(--gold) 10%, transparent);
+  color: var(--gold);
+}
+.dig-control-panel {
+  border: 1px solid var(--pane-edge);
+  border-radius: 8px;
+  background: var(--ink-2);
+}
+.dig-filter-chip {
+  border: 1px solid var(--pane-edge);
+  border-radius: 9999px;
+  background: var(--ink);
+  color: var(--paper-dim);
+  transition: color 0.15s ease;
+}
+.dig-filter-chip:hover {
+  color: var(--paper);
+}
+.dig-filter-chip.is-active {
+  border-color: var(--gold);
+  background: var(--gold);
+  color: var(--ink);
+}
+.dig-hover-row {
   border-radius: 8px;
   transition: background 0.15s ease;
 }
-.search-result-item:hover {
+.dig-hover-row:hover {
   background: var(--ink-2);
 }
-.search-pagination {
+.dig-pagination {
   border-top: 1px solid var(--pane-edge);
 }
-.search-pagination-arrow,
-.search-pagination-page {
+.dig-page-button {
   border: 1px solid var(--pane-edge);
   border-radius: 8px;
   color: var(--paper-dim);
@@ -1759,67 +1783,70 @@ body {
     border-color 0.15s ease,
     color 0.15s ease;
 }
-.search-pagination-arrow:hover,
-.search-pagination-page:hover {
+.dig-page-button:hover {
   background: var(--ink-2);
 }
-.search-pagination-arrow:disabled {
+.dig-page-button:disabled {
   cursor: not-allowed;
   opacity: 0.5;
 }
-.search-pagination-page.is-active {
+.dig-page-button.is-active {
   border-color: var(--gold);
   background: color-mix(in srgb, var(--gold) 12%, transparent);
   color: var(--gold);
 }
-.search-highlight {
+.dig-page-button--solid-active.is-active {
+  background: var(--gold);
+  color: var(--ink);
+}
+.dig-highlight {
   border-radius: 3px;
   background: color-mix(in srgb, var(--gold) 30%, transparent);
   color: var(--paper);
 }
-.search-skeleton {
+.dig-highlight--solid {
+  background: var(--gold);
+  color: var(--ink);
+}
+.dig-skeleton {
   border-radius: 8px;
   background: var(--ink-2);
 }
-.global-search-dropdown {
+.dig-floating-panel {
   border: 1px solid var(--pane-edge);
   background: var(--ink-2);
   box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.8);
 }
-.global-search-dropdown--topbar {
+.dig-floating-panel--accent-edge {
   border-color: color-mix(in srgb, var(--pane-edge) 90%, var(--gold) 10%);
   border-radius: 8px;
 }
-.global-search-result {
+.dig-result-row {
   border-bottom: 1px solid var(--pane-edge);
   border-left: 2px solid transparent;
   transition:
     background 0.15s ease,
     border-color 0.15s ease;
 }
-.global-search-result:last-child {
+.dig-result-row:last-child {
   border-bottom: 0;
 }
-.global-search-result:hover {
+.dig-result-row:hover {
   background: color-mix(in srgb, var(--ink) 50%, transparent);
 }
-.global-search-result.is-selected {
+.dig-result-row.is-selected {
   border-left-color: var(--gold);
   background: color-mix(in srgb, var(--gold) 10%, transparent);
 }
-.global-search-badge {
+.dig-badge {
   border-radius: 4px;
   background: color-mix(in srgb, var(--gold) 20%, transparent);
   color: var(--gold);
 }
-.global-search-footer {
+.dig-panel-footer {
   border-top: 1px solid var(--pane-edge);
   background: color-mix(in srgb, var(--ink) 50%, transparent);
-}
-.global-search-highlight {
-  border-radius: 3px;
-  background: var(--gold);
-  color: var(--ink);
+  color: var(--paper-dimmer);
 }
 
 /* Inline item-card previews render in a document-body portal, so these

--- a/components/site/global-search.tsx
+++ b/components/site/global-search.tsx
@@ -187,7 +187,7 @@ export function GlobalSearch({
         <button
           onClick={goToSearchPage}
           type="button"
-          className="global-search-icon-button absolute left-3 top-1/2 z-10 -translate-y-1/2"
+          className="dig-icon-button dig-icon-button--accent absolute left-3 top-1/2 z-10 -translate-y-1/2"
         >
           <Search className="h-4 w-4" />
         </button>
@@ -201,12 +201,12 @@ export function GlobalSearch({
             shouldShowPreview && query.length >= 2 && results.length > 0 && setIsOpen(true)
           }
           placeholder="Search the site..."
-          className="global-search-input w-full py-2 pl-10 pr-10 text-sm focus:outline-none"
+          className="dig-input dig-input--subtle w-full py-2 pl-10 pr-10 text-sm focus:outline-none"
         />
         {query && (
           <button
             onClick={handleClear}
-            className="global-search-clear absolute right-3 top-1/2 -translate-y-1/2"
+            className="dig-icon-button absolute right-3 top-1/2 -translate-y-1/2"
           >
             <X className="h-4 w-4" />
           </button>
@@ -218,14 +218,14 @@ export function GlobalSearch({
         <div
           className={
             variant === 'sidebar'
-              ? 'global-search-dropdown global-search-dropdown--sidebar absolute left-0 right-0 top-full z-[100] mt-2 max-h-[60vh] overflow-y-auto'
-              : 'global-search-dropdown global-search-dropdown--topbar absolute top-full z-50 mt-2 max-h-[70vh] w-full overflow-hidden overflow-y-auto'
+              ? 'dig-floating-panel absolute left-0 right-0 top-full z-[100] mt-2 max-h-[60vh] overflow-y-auto'
+              : 'dig-floating-panel dig-floating-panel--accent-edge absolute top-full z-50 mt-2 max-h-[70vh] w-full overflow-hidden overflow-y-auto'
           }
         >
           {isLoading ? (
-            <div className="global-search-empty p-4 text-center text-sm">Searching...</div>
+            <div className="dig-muted p-4 text-center text-sm">Searching...</div>
           ) : results.length === 0 ? (
-            <div className="global-search-empty p-4 text-center text-sm">No results found</div>
+            <div className="dig-muted p-4 text-center text-sm">No results found</div>
           ) : (
             <div>
               {results.map((result, index) => (
@@ -233,45 +233,41 @@ export function GlobalSearch({
                   key={result.id}
                   onClick={() => handleSelectResult(result, index)}
                   onMouseEnter={() => setSelectedIndex(index)}
-                  className={`global-search-result w-full px-4 py-3 text-left ${
+                  className={`dig-result-row w-full px-4 py-3 text-left ${
                     index === selectedIndex ? 'is-selected' : ''
                   }`}
                 >
                   {/* Item Card badge or Page Title */}
                   <div className="flex items-center gap-2 mb-1">
                     {result.type === 'itemcard' ? (
-                      <span className="global-search-badge inline-flex items-center gap-1 px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.1em]">
+                      <span className="dig-badge inline-flex items-center gap-1 px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.1em]">
                         <BookText className="h-3 w-3" />
                         Definition
                       </span>
                     ) : (
-                      <span className="global-search-result-page text-[10px] font-light uppercase tracking-[0.15em]">
+                      <span className="dig-link text-[10px] font-light uppercase tracking-[0.15em]">
                         {result.pageTitle}
                       </span>
                     )}
                     {result.type === 'itemcard' && result.pageTitle && (
-                      <span className="global-search-result-meta text-[10px]">
-                        {result.pageTitle}
-                      </span>
+                      <span className="dig-muted text-[10px]">{result.pageTitle}</span>
                     )}
                   </div>
 
                   {/* Sentence/Match */}
-                  <div className="global-search-result-sentence mb-1 line-clamp-2 text-sm font-medium">
+                  <div className="dig-copy mb-1 line-clamp-2 text-sm font-medium">
                     {highlightMatch(result.sentence, query)}
                   </div>
 
                   {/* Context */}
-                  <div className="global-search-result-context line-clamp-2 text-xs">
-                    {result.context}
-                  </div>
+                  <div className="dig-muted line-clamp-2 text-xs">{result.context}</div>
                 </button>
               ))}
             </div>
           )}
 
           {/* Footer with keyboard shortcuts */}
-          <div className="global-search-footer flex items-center justify-between px-4 py-2 text-[10px]">
+          <div className="dig-panel-footer flex items-center justify-between px-4 py-2 text-[10px]">
             {results.length > 0 ? (
               <>
                 <span>↑↓ Navigate</span>
@@ -316,7 +312,7 @@ function highlightMatch(text: string, query: string): React.ReactNode {
   const parts = text.split(new RegExp(`(${query})`, 'gi'));
   return parts.map((part, index) =>
     part.toLowerCase() === query.toLowerCase() ? (
-      <mark key={index} className="global-search-highlight px-0.5">
+      <mark key={index} className="dig-highlight dig-highlight--solid px-0.5">
         {part}
       </mark>
     ) : (

--- a/docs/style-system.md
+++ b/docs/style-system.md
@@ -65,6 +65,34 @@ The older `glass-card` class is legacy. Do not add new `glass-card` call sites.
 When touching a file that already uses it, prefer converting that local surface
 to `Pane` or a more specific Delay primitive.
 
+## Interface Recipes
+
+Bespoke app routes may need compact controls that are not editorial primitives.
+Use the shared `dig-*` recipes before adding route-specific classes:
+
+| Need                         | Use                           |
+| ---------------------------- | ----------------------------- |
+| App-route header band        | `dig-page-band`               |
+| App-route heading            | `dig-page-title`              |
+| Control input                | `dig-input`                   |
+| Subtle/translucent input     | `dig-input dig-input--subtle` |
+| Icon-only control            | `dig-icon-button`             |
+| Floating dropdown/modal pane | `dig-floating-panel`          |
+| Hoverable list row           | `dig-hover-row`               |
+| Selectable result row        | `dig-result-row`              |
+| Pagination rail              | `dig-pagination`              |
+| Pagination button            | `dig-page-button`             |
+| Search/result highlight      | `dig-highlight`               |
+| Badge                        | `dig-badge`                   |
+| Loading placeholder          | `dig-skeleton`                |
+| Muted supporting text        | `dig-muted`                   |
+| Primary body text            | `dig-copy`                    |
+| Gold link/accent text        | `dig-link`                    |
+
+Route names do not belong in global recipe names. A route may keep small local
+classes for unique layout or one-off composition, but repeated control/surface
+roles should be expressed through these shared recipes.
+
 ## Tailwind Boundary
 
 Tailwind remains the layout language.
@@ -87,6 +115,9 @@ Do not use Tailwind to create new visual identity:
 
 If a visual role repeats, make it a named Delay primitive or add one canonical
 token in `app/globals.css`.
+
+`tailwind.config.mjs` must not define an independent palette. Any named Tailwind
+color or shadow extension should point at `app/globals.css` tokens.
 
 ## Inline Styles
 

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -8,19 +8,19 @@ const config = {
   theme: {
     extend: {
       colors: {
-        background: '#0d0d0d',
-        foreground: '#e8e6e3',
-        muted: '#1a1a1a',
-        card: '#1a1a1a',
+        background: 'var(--ink)',
+        foreground: 'var(--paper)',
+        muted: 'var(--ink-3)',
+        card: 'var(--ink-2)',
         accent: {
-          DEFAULT: '#c9a961',
-          muted: '#8a7c5c',
+          DEFAULT: 'var(--gold)',
+          muted: 'var(--gold-dim)',
         },
         border: {
-          subtle: '#2a2a2a',
-          emphasis: '#3a3a3a',
+          subtle: 'var(--pane-edge)',
+          emphasis: 'var(--crack-strong)',
         },
-        success: '#5c8a5a',
+        success: 'var(--verdigris)',
       },
       fontFamily: {
         serif: [
@@ -33,7 +33,7 @@ const config = {
         mono: ['var(--font-mono)', ...defaultTheme.fontFamily.mono],
       },
       boxShadow: {
-        panel: '0 20px 50px rgba(0, 0, 0, 0.35)',
+        panel: 'var(--shadow-panel)',
       },
       typography: {
         DEFAULT: {


### PR DESCRIPTION
## What
Consolidates the app-route control styling used by search, global search, and Gatherer into shared Delay-in-Glass interface recipes.

## Why
Issue #40 is about reducing style-system drift. Search and Gatherer had parallel route-specific class sets for the same controls, panels, pagination, and feedback states. This keeps the visual display consistent with the deployed version while moving repeated visual roles into one recipe layer.

## Changes
- Add shared `dig-*` recipes
- Migrate `/search` controls
- Migrate global search dropdown
- Migrate Gatherer controls
- Tokenize Tailwind extensions
- Document recipe boundary

## Testing
- `npm run check`
- Confirm `/search` matches production visually
- Confirm global search hover/keyboard behavior
- Confirm `/gatherer` filters and pagination
