### PR TITLE
did: add traffic and search operations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,12 @@ NEXT_PUBLIC_BASE_URL=https://eldenringisthelargeglass.com
 # NEXT_PUBLIC_POSTHOG_KEY=phc_dev_xxx
 # NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
 
+# PostHog local reporting. This personal key is only for maintainer-side
+# scripts such as `npm run traffic:weekly`; never expose it to the browser.
+# POSTHOG_PERSONAL_API_KEY=phx_xxx
+# POSTHOG_PROJECT_ID=402828
+# POSTHOG_QUERY_HOST=https://us.posthog.com
+
 # Optional: free-form environment label tagged on every event. When unset,
 # the shim derives a default from Vercel's automatic VERCEL_ENV variable
 # ('production' / 'preview' / 'development') and falls back to 'local'.

--- a/app/(site)/[...slug]/page.tsx
+++ b/app/(site)/[...slug]/page.tsx
@@ -4,6 +4,7 @@ import { notFound, redirect } from 'next/navigation';
 import { ContentPageRenderer } from '@/components/site/content-page-renderer';
 import { allContentPagesSorted, getContentPageBySlug } from '@/lib/content';
 import { getFirstContentPageSlugInFolder } from '@/lib/content-tree';
+import { absoluteSiteUrl, DEFAULT_OG_IMAGE, SITE_NAME, SITE_TITLE } from '@/lib/site-metadata';
 
 interface PageProps {
   params: Promise<{ slug: string[] }>;
@@ -25,9 +26,30 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     return {};
   }
 
+  const title = `${doc.title} | ${SITE_NAME}`;
+
   return {
-    title: `${doc.title} - Elden Ring Is The Large Glass`,
+    title,
     description: doc.summary,
+    alternates: {
+      canonical: doc.url,
+    },
+    openGraph: {
+      title,
+      description: doc.summary,
+      type: 'article',
+      url: doc.url,
+      siteName: SITE_NAME,
+      publishedTime: doc.date,
+      modifiedTime: doc.updated,
+      images: [DEFAULT_OG_IMAGE],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description: doc.summary,
+      images: [DEFAULT_OG_IMAGE.url],
+    },
   };
 }
 
@@ -37,7 +59,16 @@ export default async function ContentPageRoute({ params }: PageProps) {
   const doc = getContentPageBySlug(requestedSlug);
 
   if (doc) {
-    return <ContentPageRenderer doc={doc} />;
+    return (
+      <>
+        <script
+          type="application/ld+json"
+          suppressHydrationWarning
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(contentJsonLd(doc)) }}
+        />
+        <ContentPageRenderer doc={doc} />
+      </>
+    );
   }
 
   const folderFallbackSlug = getFirstContentPageSlugInFolder(requestedSlug);
@@ -47,4 +78,30 @@ export default async function ContentPageRoute({ params }: PageProps) {
   }
 
   notFound();
+}
+
+/**
+ * Describes one MDX content document as an Article for search crawlers.
+ */
+function contentJsonLd(doc: NonNullable<ReturnType<typeof getContentPageBySlug>>) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: doc.title,
+    description: doc.summary,
+    url: absoluteSiteUrl(doc.url),
+    mainEntityOfPage: absoluteSiteUrl(doc.url),
+    datePublished: doc.date,
+    dateModified: doc.updated,
+    inLanguage: 'en-US',
+    isPartOf: {
+      '@type': 'WebSite',
+      name: SITE_TITLE,
+      url: absoluteSiteUrl('/'),
+    },
+    author: {
+      '@type': 'Person',
+      name: 'TGB',
+    },
+  };
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,15 @@ import { EB_Garamond, Inter_Tight } from 'next/font/google';
 import localFont from 'next/font/local';
 
 import './globals.css';
+import {
+  absoluteSiteUrl,
+  DEFAULT_OG_IMAGE,
+  SITE_DESCRIPTION,
+  SITE_KEYWORDS,
+  SITE_NAME,
+  SITE_ORIGIN,
+  SITE_TITLE,
+} from '@/lib/site-metadata';
 
 // Delay in Glass typography:
 //   • EB Garamond — the voice (body, headings)
@@ -36,31 +45,11 @@ const jetBrainsMono = localFont({
   variable: '--font-mono',
 });
 
-/**
- * Canonical site URL. In production this should be set via NEXT_PUBLIC_BASE_URL
- * (Vercel sets it automatically; the sitemap already reads from the same var).
- * The fallback is the eldenringisthelargeglass.com production domain so local
- * dev still renders absolute OG/Twitter image URLs rather than localhost
- * references, which silences Next's "metadataBase is not set" build-time
- * warning.
- */
-const siteUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://eldenringisthelargeglass.com';
-
 export const metadata: Metadata = {
-  metadataBase: new URL(siteUrl),
-  title: 'Elden Glass — Blockchain Verified Lore Discovery',
-  description:
-    "A groundbreaking discovery reveals Elden Ring as a digital reimagining of Marcel Duchamp's The Large Glass. Blockchain-timestamped research with cryptographic verification.",
-  keywords: [
-    'Elden Ring',
-    'Marcel Duchamp',
-    'The Large Glass',
-    'FromSoftware',
-    'Pataphysics',
-    'Game Analysis',
-    'Art History',
-    'Blockchain Verification',
-  ],
+  metadataBase: new URL(SITE_ORIGIN),
+  title: SITE_TITLE,
+  description: SITE_DESCRIPTION,
+  keywords: SITE_KEYWORDS,
   authors: [{ name: 'TGB' }],
   icons: {
     icon: '/images/dashusnavnulsigil.png',
@@ -68,29 +57,22 @@ export const metadata: Metadata = {
   },
   manifest: '/manifest.json',
   openGraph: {
-    title: 'Elden Ring Is The Large Glass - Verified Discovery',
-    description:
-      "FromSoftware's masterpiece decoded: A complete digital reimagining of Duchamp's mechanical bride fantasy.",
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
     type: 'website',
     locale: 'en_US',
-    siteName: 'Elden Glass',
-    images: [
-      {
-        url: '/images/replica-large-glass.jpg',
-        width: 800,
-        height: 533,
-        alt: 'The Large Glass replica in Tokyo',
-      },
-    ],
+    siteName: SITE_NAME,
+    url: '/',
+    images: [DEFAULT_OG_IMAGE],
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Elden Ring Is The Large Glass',
-    description:
-      "A blockchain-verified discovery proving Elden Ring reimagines Duchamp's The Large Glass",
-    images: ['/images/replica-large-glass.jpg'],
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+    images: [DEFAULT_OG_IMAGE.url],
   },
   alternates: {
+    canonical: '/',
     types: {
       'application/rss+xml': '/feed.xml',
       'text/plain': '/llms.txt',
@@ -117,10 +99,34 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en" className={fontVars} data-scroll-behavior="smooth">
       <body className="delay">
+        <script
+          type="application/ld+json"
+          suppressHydrationWarning
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(siteJsonLd()) }}
+        />
         <PostHogMount />
         {children}
         {process.env.NODE_ENV === 'development' && <AgentationDev />}
       </body>
     </html>
   );
+}
+
+/**
+ * Describes the site as a WebSite / CreativeWork for search crawlers.
+ */
+function siteJsonLd() {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    name: SITE_NAME,
+    alternateName: 'Elden Ring Is The Large Glass',
+    url: absoluteSiteUrl('/'),
+    description: SITE_DESCRIPTION,
+    inLanguage: 'en-US',
+    publisher: {
+      '@type': 'Organization',
+      name: 'Dalten Collective',
+    },
+  };
 }

--- a/docs/traffic-and-search-ops.md
+++ b/docs/traffic-and-search-ops.md
@@ -1,0 +1,61 @@
+# Traffic and Search Operations
+
+This is the maintenance loop for lightweight growth work on Elden Glass. It is
+meant to keep Codex useful without asking Eric to become the analytics operator.
+
+## Weekly Traffic Readout
+
+Run:
+
+```bash
+npm run traffic:weekly
+```
+
+The report reads PostHog through HogQL and prints a markdown summary of:
+
+- human pageviews, visitors, sessions, and last activity
+- daily human trend for the last 14 days
+- top human pages and referrers
+- agent traffic by classified identity
+- top AX request paths
+
+Required local env:
+
+```bash
+POSTHOG_PERSONAL_API_KEY=phx_...
+POSTHOG_PROJECT_ID=402828
+POSTHOG_QUERY_HOST=https://us.posthog.com
+```
+
+`POSTHOG_PROJECT_ID` and `POSTHOG_QUERY_HOST` have repo defaults for the
+current US Cloud project. The personal API key must stay local.
+
+## Search Plumbing Audit
+
+Run:
+
+```bash
+npm run audit:search
+```
+
+The audit checks the repo surfaces that control indexing and snippets:
+
+- root metadata, canonical URL, Open Graph, Twitter card, and WebSite JSON-LD
+- MDX content-page canonical, Open Graph, Twitter, and Article JSON-LD metadata
+- sitemap generation from the route catalog
+- robots sitemap plus explicit LLM API allow-listing
+- MDX frontmatter required for titles, summaries, and updated dates
+
+Use this as a regression check after changes to metadata, routing, frontmatter,
+or the route catalog. It is advisory for now; it is not wired into `npm run
+check`.
+
+## Operating Boundary
+
+PostHog answers what visitors and agents actually did on the site. Google
+Search Console answers what Google queries and indexing produced those arrivals.
+
+Do not rewrite the AX surfaces just to chase traffic. `/skill`, `/contents`,
+`/llms.txt`, and `/llms-full.txt` exist to give agents the right reading path
+once they arrive. Growth work should focus on content quality, search metadata,
+route discoverability, and external distribution.

--- a/lib/site-metadata.ts
+++ b/lib/site-metadata.ts
@@ -1,0 +1,36 @@
+export const SITE_ORIGIN =
+  process.env.NEXT_PUBLIC_BASE_URL || 'https://eldenringisthelargeglass.com';
+
+export const SITE_NAME = 'Elden Glass';
+
+export const SITE_TITLE = 'Elden Ring Is The Large Glass | Elden Glass';
+
+export const SITE_DESCRIPTION =
+  "A long-form thesis arguing that Elden Ring is a playable realization of Marcel Duchamp's The Bride Stripped Bare by Her Bachelors, Even, with evidence across The Large Glass, the Green Box, Great Runes, and FromSoftware's world design.";
+
+export const SITE_KEYWORDS = [
+  'Elden Ring',
+  'Marcel Duchamp',
+  'The Large Glass',
+  'The Bride Stripped Bare by Her Bachelors, Even',
+  'FromSoftware',
+  'Great Runes',
+  'Green Box',
+  'Pataphysics',
+  'Game analysis',
+  'Art history',
+];
+
+export const DEFAULT_OG_IMAGE = {
+  url: '/images/replica-large-glass.jpg',
+  width: 800,
+  height: 533,
+  alt: 'The Large Glass replica in Tokyo',
+};
+
+/**
+ * Resolves a site-relative path against the configured public origin.
+ */
+export function absoluteSiteUrl(pathname: string): string {
+  return new URL(pathname, SITE_ORIGIN).toString();
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "check:generated": "npm run check:critique-assets && npm run check:manuscripts",
     "check:manuscripts": "node scripts/sync-manuscripts.js --check",
     "check:tokens": "node scripts/check-css-tokens.js",
+    "traffic:weekly": "node scripts/posthog-weekly-report.js",
+    "audit:search": "node scripts/audit-search-plumbing.js",
     "audit:styles": "node scripts/audit-style-system.js",
     "lint": "eslint . --max-warnings=0",
     "lint:actions": "github-actionlint",

--- a/scripts/audit-search-plumbing.js
+++ b/scripts/audit-search-plumbing.js
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const matter = require('gray-matter');
+
+const root = process.cwd();
+const checkMode = process.argv.includes('--check');
+const findings = [];
+
+auditFileContains('app/layout.tsx', [
+  ['metadataBase', 'Root metadata declares metadataBase for absolute social URLs.'],
+  ['alternates:', 'Root metadata declares alternates.'],
+  ['canonical:', 'Root metadata declares a canonical URL.'],
+  ['openGraph:', 'Root metadata declares Open Graph defaults.'],
+  ['twitter:', 'Root metadata declares Twitter card defaults.'],
+  ['application/ld+json', 'Root layout emits structured WebSite metadata.'],
+]);
+
+auditFileContains('app/(site)/[...slug]/page.tsx', [
+  ['alternates:', 'Content pages declare canonical metadata.'],
+  ['openGraph:', 'Content pages declare Open Graph article metadata.'],
+  ['twitter:', 'Content pages declare Twitter metadata.'],
+  ['Article', 'Content pages emit Article structured data.'],
+]);
+
+auditFileContains('app/sitemap.ts', [
+  ['getRouteCatalog', 'Sitemap is generated from the route catalog.'],
+]);
+
+auditFileContains('app/robots.ts', [
+  ['sitemap:', 'Robots route advertises the sitemap.'],
+  ["'/api/llms/'", 'Robots route allows LLM API discovery.'],
+  ["'/api/'", 'Robots route disallows generic API crawling.'],
+]);
+
+auditContentFrontmatter();
+
+printReport();
+
+if (checkMode && findings.some((finding) => finding.level === 'FAIL')) {
+  process.exit(1);
+}
+
+/**
+ * Checks that a file contains a set of expected search/metadata signals.
+ */
+function auditFileContains(relativePath, expectations) {
+  const filePath = path.join(root, relativePath);
+  if (!fs.existsSync(filePath)) {
+    addFinding('FAIL', relativePath, 'File is missing.');
+    return;
+  }
+
+  const source = fs.readFileSync(filePath, 'utf8');
+  for (const [needle, message] of expectations) {
+    addFinding(source.includes(needle) ? 'PASS' : 'FAIL', relativePath, message);
+  }
+}
+
+/**
+ * Reviews MDX frontmatter that search snippets and route-catalog outputs use.
+ */
+function auditContentFrontmatter() {
+  const pagesDir = path.join(root, 'content/pages');
+  const files = listMdxFiles(pagesDir);
+  const keySlugs = new Set(['living-thesis', 'tldr', 'master-list', 'author/about']);
+
+  let complete = 0;
+  let shortSummaries = 0;
+
+  for (const filePath of files) {
+    const relativePath = path.relative(root, filePath);
+    const parsed = matter(fs.readFileSync(filePath, 'utf8'));
+    const slug = path
+      .relative(pagesDir, filePath)
+      .replace(/\\/g, '/')
+      .replace(/\.mdx?$/, '');
+
+    for (const field of ['title', 'summary', 'updated']) {
+      if (!parsed.data[field]) {
+        addFinding('FAIL', relativePath, `Missing ${field} frontmatter.`);
+      }
+    }
+
+    if (parsed.data.title && parsed.data.summary && parsed.data.updated) {
+      complete += 1;
+    }
+
+    if (typeof parsed.data.summary === 'string' && parsed.data.summary.length < 80) {
+      shortSummaries += 1;
+      addFinding('WARN', relativePath, 'Summary is short for search-result snippets.');
+    }
+
+    if (keySlugs.has(slug)) {
+      addFinding(
+        parsed.data.title && parsed.data.summary && parsed.data.updated ? 'PASS' : 'FAIL',
+        relativePath,
+        `Key route /${slug} has title, summary, and updated metadata.`
+      );
+      keySlugs.delete(slug);
+    }
+  }
+
+  for (const missingSlug of keySlugs) {
+    addFinding('FAIL', `content/pages/${missingSlug}.mdx`, 'Key route file is missing.');
+  }
+
+  addFinding(
+    'PASS',
+    'content/pages',
+    `${complete} MDX content pages have title, summary, and updated frontmatter.`
+  );
+
+  if (shortSummaries === 0) {
+    addFinding('PASS', 'content/pages', 'No content summaries are shorter than 80 characters.');
+  }
+}
+
+/**
+ * Recursively lists MDX files under a directory.
+ */
+function listMdxFiles(directory) {
+  if (!fs.existsSync(directory)) return [];
+  return fs
+    .readdirSync(directory, { withFileTypes: true })
+    .flatMap((entry) => {
+      const entryPath = path.join(directory, entry.name);
+      if (entry.isDirectory()) return listMdxFiles(entryPath);
+      return entry.isFile() && /\.mdx?$/.test(entry.name) ? [entryPath] : [];
+    })
+    .sort((left, right) => left.localeCompare(right));
+}
+
+/**
+ * Adds one audit finding.
+ */
+function addFinding(level, scope, message) {
+  findings.push({ level, scope, message });
+}
+
+/**
+ * Prints the audit in markdown for easy issue comments.
+ */
+function printReport() {
+  const counts = findings.reduce(
+    (acc, finding) => {
+      acc[finding.level] += 1;
+      return acc;
+    },
+    { PASS: 0, WARN: 0, FAIL: 0 }
+  );
+
+  console.log('# Search Plumbing Audit');
+  console.log('');
+  console.log(`PASS: ${counts.PASS}`);
+  console.log(`WARN: ${counts.WARN}`);
+  console.log(`FAIL: ${counts.FAIL}`);
+  console.log('');
+  console.log('| Level | Scope | Finding |');
+  console.log('| --- | --- | --- |');
+  for (const finding of findings) {
+    console.log(
+      `| ${finding.level} | \`${finding.scope}\` | ${finding.message.replace(/\|/g, '\\|')} |`
+    );
+  }
+}

--- a/scripts/posthog-weekly-report.js
+++ b/scripts/posthog-weekly-report.js
@@ -1,0 +1,278 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const DEFAULT_PROJECT_ID = '402828';
+const DEFAULT_HOST = 'https://us.posthog.com';
+
+loadDotenvFile('.env.local');
+loadDotenvFile('.env');
+
+const apiKey = process.env.POSTHOG_PERSONAL_API_KEY;
+const projectId = process.env.POSTHOG_PROJECT_ID || DEFAULT_PROJECT_ID;
+const posthogHost = (process.env.POSTHOG_QUERY_HOST || DEFAULT_HOST).replace(/\/$/, '');
+const environment = process.env.POSTHOG_REPORT_ENV || 'production';
+
+if (!apiKey) {
+  console.error(
+    'Missing POSTHOG_PERSONAL_API_KEY. Add it to .env.local or export it before running this report.'
+  );
+  process.exit(1);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});
+
+/**
+ * Emits a markdown weekly traffic report from PostHog HogQL.
+ */
+async function main() {
+  const [human1d, human7d, human30d, agent7d, daily, topPages, referrers, agents, axPaths] =
+    await Promise.all([
+      humanSummary(1),
+      humanSummary(7),
+      humanSummary(30),
+      agentSummary(7),
+      queryRows(
+        `
+        SELECT
+          toDate(timestamp) AS day,
+          count() AS pageviews,
+          count(DISTINCT person_id) AS visitors,
+          count(DISTINCT properties['$session_id']) AS sessions
+        FROM events
+        WHERE event = '$pageview'
+          AND properties['environment'] = {environment}
+          AND timestamp >= now() - INTERVAL 14 DAY
+        GROUP BY day
+        ORDER BY day ASC
+        `,
+        { environment }
+      ),
+      queryRows(
+        `
+        SELECT
+          coalesce(nullIf(properties['$pathname'], ''), path(properties['$current_url'])) AS path,
+          count() AS pageviews,
+          count(DISTINCT person_id) AS visitors
+        FROM events
+        WHERE event = '$pageview'
+          AND properties['environment'] = {environment}
+          AND timestamp >= now() - INTERVAL 7 DAY
+        GROUP BY path
+        ORDER BY pageviews DESC
+        LIMIT 10
+        `,
+        { environment }
+      ),
+      queryRows(
+        `
+        SELECT
+          coalesce(nullIf(properties['$referring_domain'], ''), 'direct') AS referrer,
+          count() AS pageviews,
+          count(DISTINCT person_id) AS visitors
+        FROM events
+        WHERE event = '$pageview'
+          AND properties['environment'] = {environment}
+          AND timestamp >= now() - INTERVAL 7 DAY
+        GROUP BY referrer
+        ORDER BY pageviews DESC
+        LIMIT 10
+        `,
+        { environment }
+      ),
+      queryRows(
+        `
+        SELECT
+          coalesce(nullIf(properties['agent_family'], ''), 'unknown') AS family,
+          coalesce(nullIf(properties['agent_product'], ''), 'unknown') AS product,
+          count() AS events,
+          count(DISTINCT distinct_id) AS actors,
+          max(timestamp) AS last_seen
+        FROM events
+        WHERE event = 'agent_classified'
+          AND properties['environment'] = {environment}
+          AND timestamp >= now() - INTERVAL 7 DAY
+        GROUP BY family, product
+        ORDER BY events DESC
+        LIMIT 10
+        `,
+        { environment }
+      ),
+      queryRows(
+        `
+        SELECT
+          coalesce(nullIf(properties['path'], ''), coalesce(nullIf(properties['request_path'], ''), 'unknown')) AS path,
+          coalesce(nullIf(properties['route_family'], ''), 'unknown') AS route_family,
+          count() AS requests
+        FROM events
+        WHERE event = 'ax_route_request'
+          AND properties['environment'] = {environment}
+          AND timestamp >= now() - INTERVAL 7 DAY
+        GROUP BY path, route_family
+        ORDER BY requests DESC
+        LIMIT 15
+        `,
+        { environment }
+      ),
+    ]);
+
+  console.log(`# Elden Glass Traffic Readout`);
+  console.log('');
+  console.log(`Generated: ${new Date().toISOString()}`);
+  console.log(`Environment: ${environment}`);
+  console.log('');
+  console.log(`## Human Traffic`);
+  console.log('');
+  printSummaryTable([
+    ['24h', human1d],
+    ['7d', human7d],
+    ['30d', human30d],
+  ]);
+  console.log('');
+  console.log(`## Agent Traffic`);
+  console.log('');
+  printSummaryTable([['7d', agent7d]], ['events', 'actors', 'last_seen']);
+  console.log('');
+  printTable('Daily Human Trend', daily, ['day', 'pageviews', 'visitors', 'sessions']);
+  printTable('Top Human Pages, 7d', topPages, ['path', 'pageviews', 'visitors']);
+  printTable('Human Referrers, 7d', referrers, ['referrer', 'pageviews', 'visitors']);
+  printTable('Top Agent Identities, 7d', agents, [
+    'family',
+    'product',
+    'events',
+    'actors',
+    'last_seen',
+  ]);
+  printTable('Top AX Paths, 7d', axPaths, ['path', 'route_family', 'requests']);
+}
+
+/**
+ * Queries human pageview volume for the requested lookback window.
+ */
+async function humanSummary(days) {
+  const rows = await queryRows(
+    `
+    SELECT
+      count() AS pageviews,
+      count(DISTINCT person_id) AS visitors,
+      count(DISTINCT properties['$session_id']) AS sessions,
+      max(timestamp) AS last_seen
+    FROM events
+    WHERE event = '$pageview'
+      AND properties['environment'] = {environment}
+      AND timestamp >= now() - INTERVAL ${Number(days)} DAY
+    `,
+    { environment }
+  );
+  return rows[0] || {};
+}
+
+/**
+ * Queries agent event volume for the requested lookback window.
+ */
+async function agentSummary(days) {
+  const rows = await queryRows(
+    `
+    SELECT
+      count() AS events,
+      count(DISTINCT distinct_id) AS actors,
+      max(timestamp) AS last_seen
+    FROM events
+    WHERE event IN ('agent_classified', 'ax_route_request')
+      AND properties['environment'] = {environment}
+      AND timestamp >= now() - INTERVAL ${Number(days)} DAY
+    `,
+    { environment }
+  );
+  return rows[0] || {};
+}
+
+/**
+ * Executes one HogQL query and maps returned rows to column names.
+ */
+async function queryRows(query, values = {}) {
+  const response = await fetch(`${posthogHost}/api/projects/${projectId}/query/`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      query: {
+        kind: 'HogQLQuery',
+        query,
+        values,
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`PostHog query failed (${response.status}): ${body}`);
+  }
+
+  const payload = await response.json();
+  const columns = payload.columns || [];
+  return (payload.results || []).map((row) =>
+    Object.fromEntries(columns.map((column, index) => [column, row[index]]))
+  );
+}
+
+/**
+ * Loads simple KEY=value dotenv files without adding a runtime dependency.
+ */
+function loadDotenvFile(filename) {
+  const filePath = path.join(process.cwd(), filename);
+  if (!fs.existsSync(filePath)) return;
+
+  for (const rawLine of fs.readFileSync(filePath, 'utf8').split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const match = line.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+    if (!match || process.env[match[1]]) continue;
+    process.env[match[1]] = match[2].replace(/^['"]|['"]$/g, '');
+  }
+}
+
+/**
+ * Prints a summary table for lookback-window metrics.
+ */
+function printSummaryTable(rows, metrics = ['pageviews', 'visitors', 'sessions', 'last_seen']) {
+  console.log(`| Window | ${metrics.join(' | ')} |`);
+  console.log(`| --- | ${metrics.map(() => '---:').join(' | ')} |`);
+  for (const [label, row] of rows) {
+    console.log(`| ${label} | ${metrics.map((metric) => formatValue(row[metric])).join(' | ')} |`);
+  }
+}
+
+/**
+ * Prints a titled markdown table.
+ */
+function printTable(title, rows, columns) {
+  console.log('');
+  console.log(`## ${title}`);
+  console.log('');
+  if (rows.length === 0) {
+    console.log('_No rows returned._');
+    console.log('');
+    return;
+  }
+  console.log(`| ${columns.join(' | ')} |`);
+  console.log(`| ${columns.map(() => '---').join(' | ')} |`);
+  for (const row of rows) {
+    console.log(`| ${columns.map((column) => formatValue(row[column])).join(' | ')} |`);
+  }
+  console.log('');
+}
+
+/**
+ * Escapes markdown table cells and keeps nullish values legible.
+ */
+function formatValue(value) {
+  if (value === null || value === undefined || value === '') return '-';
+  return String(value).replace(/\|/g, '\\|');
+}


### PR DESCRIPTION
## What

Adds maintainer-side traffic/search operations: a PostHog weekly readout, an advisory search plumbing audit, and shared site metadata for stronger snippets.

## Why

We need Codex to own the recurring traffic readout and basic search hygiene checks without changing the AX reading surfaces or asking Eric to operate PostHog by hand.

## Changes

- Add PostHog traffic readout
- Add search plumbing audit
- Centralize site metadata
- Add canonical and JSON-LD metadata
- Document weekly ops loop
- Document local PostHog report env

## Testing

- npm run traffic:weekly
- npm run audit:search
- npm run audit:title-cards
- npm run check:title-cards
- npm run lint
- npm run lint:actions
- npm run format:check
- npm run typecheck
- npm run test
- NEXT_TELEMETRY_DISABLED=1 npm run build
- npm run check
