### PR TITLE
did: add Bing site verification file

### DIFF
--- a/public/BingSiteAuth.xml
+++ b/public/BingSiteAuth.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<users>
+	<user>95C15B503CFC2E589987F77B320E6496</user>
+</users>


### PR DESCRIPTION
## What

Adds the Bing Webmaster Tools XML verification file at the site root.

## Why

Bing requires a root-hosted verification file before the site can be added to Webmaster Tools and before IndexNow receipt can be inspected from the dashboard.

## Changes

- Add BingSiteAuth.xml

## Testing

- npm run format:check
- npm run lint
- NEXT_TELEMETRY_DISABLED=1 npm run build
