### PR TITLE
chore: promote Bing verification to main

### DIFF
--- a/public/BingSiteAuth.xml
+++ b/public/BingSiteAuth.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<users>
+	<user>95C15B503CFC2E589987F77B320E6496</user>
+</users>


### PR DESCRIPTION
## What

Promotes the current dev branch to main, including the Bing Webmaster Tools verification file.

## Why

Bing needs the XML verification file available on the production domain before the site can be verified in Webmaster Tools.

## Changes

- Promote BingSiteAuth.xml

## Testing

- PR #93 checks passed
- NEXT_TELEMETRY_DISABLED=1 npm run build passed locally
