### PR TITLE
chore: add Google Search Console verification

### DIFF
--- a/public/google13526896e1aa770e.html
+++ b/public/google13526896e1aa770e.html
@@ -1,0 +1,1 @@
+google-site-verification: google13526896e1aa770e.html


### PR DESCRIPTION
## What
Adds the Google Search Console HTML verification file at the public root so Google can verify the URL-prefix property for eldenringisthelargeglass.com.

## Why
Google Search Console needs ownership verification before we can submit the sitemap and inspect indexing state from the API/UI. This file is the verification artifact returned by Google's Site Verification API.

## Changes
- Added Google verification file

## Testing
- `npm run typecheck`
- Confirmed `/sitemap.xml` returns `200`
