### PR TITLE
chore: promote Google Search Console verification

### DIFF
--- a/public/google13526896e1aa770e.html
+++ b/public/google13526896e1aa770e.html
@@ -1,0 +1,1 @@
+google-site-verification: google13526896e1aa770e.html


### PR DESCRIPTION
## What
Promotes the Google Search Console verification file from dev to main.

## Why
The verification file must be live on the production domain before Google can verify ownership and accept sitemap submission for eldenringisthelargeglass.com.

## Changes
- Promotes Google verification artifact

## Testing
- PR #95 checks passed against dev
- `npm run typecheck`
