### PR TITLE
chore: serve Google verification route

### DIFF
--- a/app/google13526896e1aa770e.html/route.ts
+++ b/app/google13526896e1aa770e.html/route.ts
@@ -1,0 +1,13 @@
+const GOOGLE_SITE_VERIFICATION = 'google-site-verification: google13526896e1aa770e.html';
+
+/**
+ * Serves the exact Google Search Console verification response at the
+ * root-level HTML token path.
+ */
+export function GET() {
+  return new Response(GOOGLE_SITE_VERIFICATION, {
+    headers: {
+      'content-type': 'text/html; charset=utf-8',
+    },
+  });
+}


### PR DESCRIPTION
## What
Adds an explicit route handler for Google's Search Console verification token path.

## Why
The static verification file was committed and promoted, but production still routed the `.html` token path through the catch-all page. Google needs the exact verification body at that root URL before it can verify the property and accept sitemap submission.

## Changes
- Added exact Google verification route
- Preserved the static token file

## Testing
- `npm run typecheck`
- Confirmed production was serving the catch-all for the static token path before this route fix
