### PR TITLE
chore: promote Google verification route

### DIFF
--- a/app/google13526896e1aa770e.html/route.ts
+++ b/app/google13526896e1aa770e.html/route.ts
@@ -1,0 +1,13 @@
+const GOOGLE_SITE_VERIFICATION = 'google-site-verification: google13526896e1aa770e.html';
+
+/**
+ * Serves the exact Google Search Console verification response at the
+ * root-level HTML token path.
+ */
+export function GET() {
+  return new Response(GOOGLE_SITE_VERIFICATION, {
+    headers: {
+      'content-type': 'text/html; charset=utf-8',
+    },
+  });
+}

--- a/public/google13526896e1aa770e.html
+++ b/public/google13526896e1aa770e.html
@@ -1,0 +1,1 @@
+google-site-verification: google13526896e1aa770e.html


### PR DESCRIPTION
## What
Promotes the Google verification route from dev to main.

## Why
The production domain must return Google's exact verification token body before Search Console can verify the site and accept sitemap submission.

## Changes
- Promotes exact verification route

## Testing
- PR #97 checks passed against dev
- `npm run typecheck`
