### PR TITLE
fix: promote clarified site title

### DIFF
--- a/app/feed.xml/route.ts
+++ b/app/feed.xml/route.ts
@@ -36,9 +36,9 @@ function generateRss(items: FeedItem[]): string {
   return `<?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
-    <title>Elden Glass - The Large Glass Discovery</title>
+    <title>Elden Glass - Elden Ring and Marcel Duchamp's Large Glass</title>
     <link>${BASE_URL}</link>
-    <description>Elden Ring is a digital reimagining of Marcel Duchamp's The Bride Stripped Bare by Her Bachelors, Even. Blockchain-verified research proving FromSoftware's masterpiece is a 'pataphysical artwork.</description>
+    <description>Elden Ring is a digital reimagining of Marcel Duchamp's The Bride Stripped Bare by Her Bachelors, Even. Long-form art criticism tracing FromSoftware's masterpiece through The Large Glass, the Green Box, and 'pataphysics.</description>
     <language>en-us</language>
     <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>
     <atom:link href="${BASE_URL}/feed.xml" rel="self" type="application/rss+xml"/>

--- a/app/google13526896e1aa770e.html/route.ts
+++ b/app/google13526896e1aa770e.html/route.ts
@@ -1,0 +1,13 @@
+const GOOGLE_SITE_VERIFICATION = 'google-site-verification: google13526896e1aa770e.html';
+
+/**
+ * Serves the exact Google Search Console verification response at the
+ * root-level HTML token path.
+ */
+export function GET() {
+  return new Response(GOOGLE_SITE_VERIFICATION, {
+    headers: {
+      'content-type': 'text/html; charset=utf-8',
+    },
+  });
+}

--- a/lib/site-metadata.ts
+++ b/lib/site-metadata.ts
@@ -3,7 +3,7 @@ export const SITE_ORIGIN =
 
 export const SITE_NAME = 'Elden Glass';
 
-export const SITE_TITLE = 'Elden Ring Is The Large Glass | Elden Glass';
+export const SITE_TITLE = "Elden Glass - Elden Ring and Marcel Duchamp's Large Glass";
 
 export const SITE_DESCRIPTION =
   "A long-form thesis arguing that Elden Ring is a playable realization of Marcel Duchamp's The Bride Stripped Bare by Her Bachelors, Even, with evidence across The Large Glass, the Green Box, Great Runes, and FromSoftware's world design.";

--- a/public/google13526896e1aa770e.html
+++ b/public/google13526896e1aa770e.html
@@ -1,0 +1,1 @@
+google-site-verification: google13526896e1aa770e.html

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "Elden Glass - The Large Glass Discovery",
+  "name": "Elden Glass - Elden Ring and Marcel Duchamp's Large Glass",
   "short_name": "Elden Glass",
   "description": "Elden Ring is a digital reimagining of Marcel Duchamp's The Bride Stripped Bare by Her Bachelors, Even",
   "start_url": "/",


### PR DESCRIPTION
## What
Promotes the clarified public site title from `dev` to `main`.

## Why
Production should lead with the Elden Ring and Marcel Duchamp hook rather than stale proof-mechanics or vague discovery framing.

## Changes
- Promotes canonical metadata title
- Promotes manifest title alignment
- Promotes RSS title and description cleanup

## Testing
- Passed on PR #99 into `dev`
- `npm run typecheck`
- `npm run build`
