### PR TITLE
refactor: converge proof card styling

### DIFF
--- a/components/ui/card-skeleton.tsx
+++ b/components/ui/card-skeleton.tsx
@@ -2,40 +2,40 @@ export function CardSkeleton() {
   return (
     <div className="animate-pulse space-y-4 p-6">
       {/* Title */}
-      <div className="h-8 bg-[var(--bg-tertiary)] rounded w-3/4" />
+      <div className="dig-skeleton h-8 w-3/4" />
 
       {/* Category badge */}
       <div className="flex gap-2">
-        <div className="h-5 bg-[var(--bg-tertiary)] rounded w-20" />
-        <div className="h-5 bg-[var(--bg-tertiary)] rounded w-16" />
+        <div className="dig-skeleton h-5 w-20" />
+        <div className="dig-skeleton h-5 w-16" />
       </div>
 
       {/* Description lines */}
       <div className="space-y-2 pt-4">
-        <div className="h-4 bg-[var(--bg-tertiary)] rounded w-full" />
-        <div className="h-4 bg-[var(--bg-tertiary)] rounded w-full" />
-        <div className="h-4 bg-[var(--bg-tertiary)] rounded w-5/6" />
-        <div className="h-4 bg-[var(--bg-tertiary)] rounded w-4/6" />
+        <div className="dig-skeleton h-4 w-full" />
+        <div className="dig-skeleton h-4 w-full" />
+        <div className="dig-skeleton h-4 w-5/6" />
+        <div className="dig-skeleton h-4 w-4/6" />
       </div>
 
       {/* Connections section */}
       <div className="pt-6 space-y-3">
-        <div className="h-5 bg-[var(--bg-tertiary)] rounded w-24" />
+        <div className="dig-skeleton h-5 w-24" />
         <div className="flex gap-2">
-          <div className="h-8 bg-[var(--bg-tertiary)] rounded w-28" />
-          <div className="h-8 bg-[var(--bg-tertiary)] rounded w-32" />
-          <div className="h-8 bg-[var(--bg-tertiary)] rounded w-24" />
+          <div className="dig-skeleton h-8 w-28" />
+          <div className="dig-skeleton h-8 w-32" />
+          <div className="dig-skeleton h-8 w-24" />
         </div>
       </div>
 
       {/* Semantic tags */}
       <div className="pt-4 space-y-2">
-        <div className="h-4 bg-[var(--bg-tertiary)] rounded w-28" />
+        <div className="dig-skeleton h-4 w-28" />
         <div className="flex flex-wrap gap-1">
-          <div className="h-6 bg-[var(--bg-tertiary)] rounded w-16" />
-          <div className="h-6 bg-[var(--bg-tertiary)] rounded w-20" />
-          <div className="h-6 bg-[var(--bg-tertiary)] rounded w-14" />
-          <div className="h-6 bg-[var(--bg-tertiary)] rounded w-18" />
+          <div className="dig-skeleton h-6 w-16" />
+          <div className="dig-skeleton h-6 w-20" />
+          <div className="dig-skeleton h-6 w-14" />
+          <div className="dig-skeleton h-6 w-18" />
         </div>
       </div>
     </div>
@@ -48,13 +48,13 @@ export function CardGridSkeleton({ count = 6 }: { count?: number }) {
       {Array.from({ length: count }).map((_, i) => (
         <div
           key={i}
-          className="animate-pulse border border-[var(--border-subtle)] rounded-lg p-4 space-y-3"
+          className="animate-pulse space-y-3 rounded-lg border border-[var(--pane-edge)] p-4"
         >
-          <div className="h-6 bg-[var(--bg-tertiary)] rounded w-3/4" />
-          <div className="h-4 bg-[var(--bg-tertiary)] rounded w-1/4" />
+          <div className="dig-skeleton h-6 w-3/4" />
+          <div className="dig-skeleton h-4 w-1/4" />
           <div className="space-y-2">
-            <div className="h-3 bg-[var(--bg-tertiary)] rounded w-full" />
-            <div className="h-3 bg-[var(--bg-tertiary)] rounded w-5/6" />
+            <div className="dig-skeleton h-3 w-full" />
+            <div className="dig-skeleton h-3 w-5/6" />
           </div>
         </div>
       ))}
@@ -68,12 +68,12 @@ export function SearchResultsSkeleton() {
       {Array.from({ length: 5 }).map((_, i) => (
         <div
           key={i}
-          className="animate-pulse flex items-center gap-3 p-3 rounded-lg bg-[var(--bg-secondary)]"
+          className="flex animate-pulse items-center gap-3 rounded-lg bg-[var(--ink-2)] p-3"
         >
-          <div className="h-10 w-10 bg-[var(--bg-tertiary)] rounded" />
+          <div className="dig-skeleton h-10 w-10" />
           <div className="flex-1 space-y-2">
-            <div className="h-4 bg-[var(--bg-tertiary)] rounded w-2/3" />
-            <div className="h-3 bg-[var(--bg-tertiary)] rounded w-1/3" />
+            <div className="dig-skeleton h-4 w-2/3" />
+            <div className="dig-skeleton h-3 w-1/3" />
           </div>
         </div>
       ))}

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -6,7 +6,7 @@ const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElemen
     <div
       ref={ref}
       className={cn(
-        'rounded-2xl border border-[var(--border-subtle)] bg-[var(--bg-secondary)] shadow-panel',
+        'rounded-2xl border border-[var(--pane-edge)] bg-[var(--ink-2)] shadow-panel',
         className
       )}
       {...props}
@@ -26,7 +26,7 @@ const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HT
   ({ className, ...props }, ref) => (
     <h3
       ref={ref}
-      className={cn('font-serif text-xl text-[var(--text-primary)]', className)}
+      className={cn('font-serif text-xl text-[var(--paper)]', className)}
       {...props}
     />
   )
@@ -37,7 +37,7 @@ const CardDescription = React.forwardRef<
   HTMLParagraphElement,
   React.HTMLAttributes<HTMLParagraphElement>
 >(({ className, ...props }, ref) => (
-  <p ref={ref} className={cn('text-sm text-[var(--text-secondary)]', className)} {...props} />
+  <p ref={ref} className={cn('text-sm text-[var(--paper-dim)]', className)} {...props} />
 ));
 CardDescription.displayName = 'CardDescription';
 

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -24,11 +24,7 @@ CardHeader.displayName = 'CardHeader';
 
 const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
   ({ className, ...props }, ref) => (
-    <h3
-      ref={ref}
-      className={cn('font-serif text-xl text-[var(--paper)]', className)}
-      {...props}
-    />
+    <h3 ref={ref} className={cn('font-serif text-xl text-[var(--paper)]', className)} {...props} />
   )
 );
 CardTitle.displayName = 'CardTitle';

--- a/components/verification/hash-verification.tsx
+++ b/components/verification/hash-verification.tsx
@@ -4,6 +4,7 @@ import { ArrowUpRight, Download, ShieldCheck } from 'lucide-react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { CopyButton } from '@/components/site/copy-button';
+import { Eyebrow, Pane, Spec } from '@/components/delay';
 
 interface HashVerificationProps {
   /** The SHA-256 hash of the source file. */
@@ -54,7 +55,7 @@ export function HashVerification({
       <Card>
         <CardHeader className="flex flex-col gap-2">
           <div className="flex items-center gap-3">
-            <div className="rounded-full bg-[rgb(var(--success-green-rgb)/0.1)] p-2 text-[var(--success-green)]">
+            <div className="rounded-full bg-[color-mix(in_srgb,var(--verdigris)_10%,transparent)] p-2 text-[var(--verdigris)]">
               <ShieldCheck className="h-5 w-5" />
             </div>
             <div>
@@ -68,15 +69,13 @@ export function HashVerification({
           </div>
         </CardHeader>
         <CardContent className="space-y-4">
-          <div className="rounded-xl border border-[var(--border-emphasis)] bg-[rgb(var(--bg-primary-rgb)/0.8)] p-4 font-mono text-sm text-[var(--accent-gold)]">
+          <Pane solid className="rounded-xl p-4 font-mono text-sm text-[var(--gold)]">
             <div className="flex items-center justify-between gap-4">
-              <span className="uppercase text-[0.65rem] tracking-[0.3em] text-[var(--text-tertiary)]">
-                SHA-256 Hash
-              </span>
+              <Eyebrow>SHA-256 Hash</Eyebrow>
               <CopyButton value={documentHash} label="Copy hash" />
             </div>
-            <p className="mt-3 break-all text-[var(--text-primary)]">{documentHash}</p>
-          </div>
+            <p className="mt-3 break-all text-[var(--paper)]">{documentHash}</p>
+          </Pane>
 
           <div className="flex flex-wrap gap-3">
             {easUrl && (
@@ -120,42 +119,42 @@ export function HashVerification({
         </CardHeader>
         <CardContent className="space-y-5">
           <section className="space-y-2">
-            <p className="text-sm font-semibold text-[var(--text-primary)]">
+            <p className="text-sm font-semibold text-[var(--paper)]">
               1. Confirm the hash matches the file
             </p>
-            <p className="text-sm text-[var(--text-secondary)]">
+            <p className="text-sm text-[var(--paper-dim)]">
               Download the hashable file and compute its SHA-256 hash. The result must match the
               hash above.
             </p>
-            <div className="glass-card border border-dashed border-[var(--border-emphasis)] bg-[rgb(var(--bg-primary-rgb)/0.5)] p-4 text-xs">
-              <pre className="overflow-x-auto text-[var(--text-secondary)]">{`curl -O https://eldenringisthelargeglass.com${hashableFileUrl}
+            <Pane solid className="rounded-lg border-dashed border-[var(--crack-strong)] p-4 text-xs">
+              <pre className="overflow-x-auto text-[var(--paper-dim)]">{`curl -O https://eldenringisthelargeglass.com${hashableFileUrl}
 shasum -a 256 ${hashableFile}`}</pre>
-            </div>
+            </Pane>
           </section>
 
           {bitcoinOts && (
             <section className="space-y-2">
-              <p className="text-sm font-semibold text-[var(--text-primary)]">
+              <p className="text-sm font-semibold text-[var(--paper)]">
                 {stepNumber++}. Verify the Bitcoin timestamp
               </p>
-              <p className="text-sm text-[var(--text-secondary)]">
+              <p className="text-sm text-[var(--paper-dim)]">
                 Download the OpenTimestamps proof file and verify it against the hashable file with
-                the <code className="text-[var(--accent-gold)]">ots</code> client. This proves the
+                the <code className="text-[var(--gold)]">ots</code> client. This proves the
                 document existed at the Bitcoin block height recorded in the proof, which cannot be
                 backdated.
               </p>
-              <div className="glass-card border border-dashed border-[var(--border-emphasis)] bg-[rgb(var(--bg-primary-rgb)/0.5)] p-4 text-xs">
-                <pre className="overflow-x-auto text-[var(--text-secondary)]">{`pip install opentimestamps-client
+              <Pane solid className="rounded-lg border-dashed border-[var(--crack-strong)] p-4 text-xs">
+                <pre className="overflow-x-auto text-[var(--paper-dim)]">{`pip install opentimestamps-client
 curl -O https://eldenringisthelargeglass.com${otsFileUrl}
 ots verify -f ${hashableFile} ${bitcoinOts}`}</pre>
-              </div>
-              <p className="text-xs text-[var(--text-tertiary)]">
+              </Pane>
+              <p className="text-xs text-[var(--paper-dimmer)]">
                 Or upload the <code>.ots</code> file at{' '}
                 <Link
                   href={'https://opentimestamps.org/' as any}
                   target="_blank"
                   rel="noreferrer"
-                  className="text-[var(--accent-gold)] underline"
+                  className="text-[var(--gold)] underline"
                 >
                   opentimestamps.org
                 </Link>{' '}
@@ -166,17 +165,22 @@ ots verify -f ${hashableFile} ${bitcoinOts}`}</pre>
 
           {ethereumAttestation && (
             <section className="space-y-2">
-              <p className="text-sm font-semibold text-[var(--text-primary)]">
+              <p className="text-sm font-semibold text-[var(--paper)]">
                 {stepNumber++}. Verify the Ethereum attestation
               </p>
-              <p className="text-sm text-[var(--text-secondary)]">
+              <p className="text-sm text-[var(--paper-dim)]">
                 Visit the Ethereum Attestation Service (EAS) record linked above. It contains the
                 document hash, the attester&apos;s signature, and the block timestamp.
               </p>
-              <div className="glass-card border border-dashed border-[var(--border-emphasis)] bg-[rgb(var(--bg-primary-rgb)/0.5)] p-4 text-xs font-mono">
-                <p className="text-[var(--text-tertiary)]">UID</p>
-                <p className="break-all text-[var(--text-secondary)]">{ethereumAttestation}</p>
-              </div>
+              <Pane
+                solid
+                className="rounded-lg border-dashed border-[var(--crack-strong)] p-4 text-xs font-mono"
+              >
+                <p>
+                  <Spec>UID</Spec>
+                </p>
+                <p className="break-all text-[var(--paper-dim)]">{ethereumAttestation}</p>
+              </Pane>
             </section>
           )}
         </CardContent>

--- a/components/verification/hash-verification.tsx
+++ b/components/verification/hash-verification.tsx
@@ -126,7 +126,10 @@ export function HashVerification({
               Download the hashable file and compute its SHA-256 hash. The result must match the
               hash above.
             </p>
-            <Pane solid className="rounded-lg border-dashed border-[var(--crack-strong)] p-4 text-xs">
+            <Pane
+              solid
+              className="rounded-lg border-dashed border-[var(--crack-strong)] p-4 text-xs"
+            >
               <pre className="overflow-x-auto text-[var(--paper-dim)]">{`curl -O https://eldenringisthelargeglass.com${hashableFileUrl}
 shasum -a 256 ${hashableFile}`}</pre>
             </Pane>
@@ -139,11 +142,14 @@ shasum -a 256 ${hashableFile}`}</pre>
               </p>
               <p className="text-sm text-[var(--paper-dim)]">
                 Download the OpenTimestamps proof file and verify it against the hashable file with
-                the <code className="text-[var(--gold)]">ots</code> client. This proves the
-                document existed at the Bitcoin block height recorded in the proof, which cannot be
+                the <code className="text-[var(--gold)]">ots</code> client. This proves the document
+                existed at the Bitcoin block height recorded in the proof, which cannot be
                 backdated.
               </p>
-              <Pane solid className="rounded-lg border-dashed border-[var(--crack-strong)] p-4 text-xs">
+              <Pane
+                solid
+                className="rounded-lg border-dashed border-[var(--crack-strong)] p-4 text-xs"
+              >
                 <pre className="overflow-x-auto text-[var(--paper-dim)]">{`pip install opentimestamps-client
 curl -O https://eldenringisthelargeglass.com${otsFileUrl}
 ots verify -f ${hashableFile} ${bitcoinOts}`}</pre>


### PR DESCRIPTION
## What
This PR takes the next narrow style-system convergence slice for issue #40 by migrating the shared Card surface, reusable card skeletons, and cryptographic proof verification panels onto canonical Delay in Glass tokens and primitives.

## Why
The proof card area was visually stable but still carried legacy token aliases, hand-rolled `glass-card` surfaces, and repeated skeleton styling. This keeps the visual display consistent with the deployed version while reducing the audit baseline in a small, reviewable component slice.

## Changes
- Migrates Card aliases
- Reuses `dig-skeleton`
- Converts proof panels
- Keeps layout unchanged

## Testing
- `npm run audit:styles`
  - total drift signals: 697, down from 762
- `npm run build`
  - production build completes successfully
- Manual visual review on `localhost:4002/tldr` and `localhost:4002/initial-thesis`
  - approved in local review
