### PR TITLE
refactor: converge duchamp works styling

### DIFF
--- a/components/duchamp-works/duchamp-work-tile.tsx
+++ b/components/duchamp-works/duchamp-work-tile.tsx
@@ -24,14 +24,7 @@ export function DuchampWorkTile({ artwork, onSelect }: DuchampWorkTileProps) {
       onClick={() => onSelect(artwork)}
       className="group flex cursor-pointer flex-col gap-3 text-left focus-visible:outline-none"
     >
-      <div
-        className="relative aspect-[3/4] cursor-pointer overflow-hidden rounded-sm ring-1 ring-[rgb(201_169_97/0.12)] transition-[box-shadow,transform,ring-color] duration-500 ease-out group-hover:-translate-y-0.5 group-hover:ring-[rgb(201_169_97/0.55)] group-focus-visible:ring-2 group-focus-visible:ring-[var(--accent-gold)]"
-        style={{
-          background: 'linear-gradient(135deg, #12100d 0%, #1a1511 50%, #12100d 100%)',
-          boxShadow:
-            '0 0 24px rgba(0,0,0,0.65), inset 0 1px 1px rgba(201,169,97,0.08), inset 0 -1px 1px rgba(0,0,0,0.4)',
-        }}
-      >
+      <div className="pane pane--solid relative aspect-[3/4] cursor-pointer overflow-hidden rounded-sm bg-[linear-gradient(135deg,var(--ink-2)_0%,var(--ink-3)_50%,var(--ink-2)_100%)] ring-1 ring-[color-mix(in_srgb,var(--gold)_12%,transparent)] transition-[box-shadow,transform,ring-color] duration-500 ease-out group-hover:-translate-y-0.5 group-hover:ring-[color-mix(in_srgb,var(--gold)_55%,transparent)] group-focus-visible:ring-2 group-focus-visible:ring-[var(--gold)]">
         {imagePath && !imageFailed ? (
           <Image
             src={imagePath}
@@ -43,25 +36,19 @@ export function DuchampWorkTile({ artwork, onSelect }: DuchampWorkTileProps) {
             onError={() => setImageFailed(true)}
           />
         ) : (
-          <div className="flex h-full items-center justify-center p-4 text-center font-serif text-sm italic text-[var(--text-tertiary)]">
+          <div className="flex h-full items-center justify-center p-4 text-center font-serif text-sm italic text-[var(--paper-dimmer)]">
             Image not available
           </div>
         )}
-        <div
-          className="pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-500 group-hover:opacity-100"
-          style={{
-            background:
-              'radial-gradient(circle at 50% 40%, rgba(201,169,97,0.08) 0%, transparent 70%)',
-          }}
-        />
+        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_50%_40%,color-mix(in_srgb,var(--gold)_8%,transparent)_0%,transparent_70%)] opacity-0 transition-opacity duration-500 group-hover:opacity-100" />
       </div>
 
       <div className="space-y-0.5 px-1">
-        <h3 className="font-serif text-sm leading-snug text-[var(--text-primary)] transition-colors duration-300 group-hover:text-[var(--accent-gold)]">
+        <h3 className="font-serif text-sm leading-snug text-[var(--paper)] transition-colors duration-300 group-hover:text-[var(--gold)]">
           {artwork.title}
         </h3>
         {artwork.artwork.year && (
-          <p className="font-serif text-xs italic text-[var(--text-tertiary)]">
+          <p className="font-serif text-xs italic text-[var(--paper-dimmer)]">
             {artwork.artwork.year}
           </p>
         )}

--- a/components/duchamp-works/work-detail-modal.tsx
+++ b/components/duchamp-works/work-detail-modal.tsx
@@ -22,10 +22,8 @@ interface MetaPairProps {
 function MetaPair({ label, children }: MetaPairProps) {
   return (
     <div className="space-y-1">
-      <dt className="text-[0.6rem] font-medium uppercase tracking-[0.22em] text-[var(--accent-gold)]">
-        {label}
-      </dt>
-      <dd className="font-serif text-sm leading-relaxed text-[var(--text-primary)]">{children}</dd>
+      <dt className="eyebrow eyebrow--gold">{label}</dt>
+      <dd className="font-serif text-sm leading-relaxed text-[var(--paper)]">{children}</dd>
     </div>
   );
 }
@@ -53,32 +51,20 @@ export function WorkDetailModal({ artwork, open, onOpenChange }: WorkDetailModal
   return (
     <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
       <DialogPrimitive.Portal>
-        <DialogPrimitive.Overlay className="fixed inset-0 z-[90] bg-[rgba(0,0,0,0.82)] backdrop-blur-md" />
+        <DialogPrimitive.Overlay className="fixed inset-0 z-[90] bg-[color-mix(in_srgb,var(--ink)_82%,transparent)] backdrop-blur-md" />
 
         <DialogPrimitive.Content
           aria-describedby={undefined}
-          className="fixed left-1/2 top-1/2 z-[100] grid h-[min(85vh,44rem)] w-[min(96vw,64rem)] -translate-x-1/2 -translate-y-1/2 grid-rows-[minmax(0,1fr)_auto] overflow-hidden rounded-sm border border-[rgb(201_169_97/0.2)] outline-none md:grid-cols-[minmax(0,1.35fr)_minmax(20rem,1fr)] md:grid-rows-1"
-          style={{
-            background: 'linear-gradient(135deg, #15120e 0%, #1c1813 50%, #15120e 100%)',
-            boxShadow:
-              '0 30px 80px rgba(0,0,0,0.85), 0 0 0 1px rgba(201,169,97,0.08), inset 0 1px 1px rgba(201,169,97,0.08)',
-          }}
+          className="fixed left-1/2 top-1/2 z-[100] grid h-[min(85vh,44rem)] w-[min(96vw,64rem)] -translate-x-1/2 -translate-y-1/2 grid-rows-[minmax(0,1fr)_auto] overflow-hidden rounded-sm border border-[color-mix(in_srgb,var(--gold)_20%,var(--pane-edge))] bg-[linear-gradient(135deg,var(--ink-2)_0%,var(--ink-3)_50%,var(--ink-2)_100%)] shadow-2xl outline-none md:grid-cols-[minmax(0,1.35fr)_minmax(20rem,1fr)] md:grid-rows-1"
         >
           <DialogPrimitive.Close
             aria-label="Close artwork details"
-            className="absolute right-3 top-3 z-10 flex h-8 w-8 items-center justify-center rounded-full border border-[rgb(201_169_97/0.25)] bg-[rgba(10,8,6,0.75)] text-[var(--text-secondary)] backdrop-blur-sm transition-colors hover:border-[var(--accent-gold)] hover:text-[var(--accent-gold)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-gold)]"
+            className="absolute right-3 top-3 z-10 flex h-8 w-8 items-center justify-center rounded-full border border-[color-mix(in_srgb,var(--gold)_25%,transparent)] bg-[color-mix(in_srgb,var(--ink)_75%,transparent)] text-[var(--paper-dim)] backdrop-blur-sm transition-colors hover:border-[var(--gold)] hover:text-[var(--gold)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--gold)]"
           >
             <X className="h-4 w-4" strokeWidth={2.25} />
           </DialogPrimitive.Close>
 
-          <div
-            className="relative flex min-h-0 items-center justify-center p-4 sm:p-6 md:p-8"
-            style={{
-              background:
-                'radial-gradient(ellipse at center, #0d0b09 0%, #05040400 70%), linear-gradient(135deg, #0a0807 0%, #0f0c09 100%)',
-              boxShadow: 'inset 0 0 80px rgba(0,0,0,0.6)',
-            }}
-          >
+          <div className="relative flex min-h-0 items-center justify-center bg-[radial-gradient(ellipse_at_center,color-mix(in_srgb,var(--ink-3)_80%,var(--ink))_0%,transparent_70%),linear-gradient(135deg,var(--ink)_0%,var(--ink-2)_100%)] p-4 shadow-inner sm:p-6 md:p-8">
             {imagePath && !imageFailed ? (
               <div className="relative h-full w-full">
                 <Image
@@ -86,35 +72,33 @@ export function WorkDetailModal({ artwork, open, onOpenChange }: WorkDetailModal
                   alt={artwork.title}
                   fill
                   sizes="(max-width: 768px) 96vw, 55vw"
-                  className="object-contain drop-shadow-[0_20px_40px_rgba(0,0,0,0.7)]"
+                  className="object-contain drop-shadow-2xl"
                   unoptimized={imagePath.startsWith('/')}
                   onError={() => setImageFailed(true)}
                 />
               </div>
             ) : (
-              <p className="font-serif text-base italic text-[var(--text-tertiary)]">
+              <p className="font-serif text-base italic text-[var(--paper-dimmer)]">
                 Image not available
               </p>
             )}
           </div>
 
-          <div className="flex min-h-0 flex-col overflow-y-auto border-t border-[rgb(201_169_97/0.12)] md:border-l md:border-t-0">
-            <div className="space-y-1.5 border-b border-[rgb(201_169_97/0.12)] px-6 pb-5 pt-6">
-              <p className="text-[0.6rem] uppercase tracking-[0.3em] text-[var(--accent-gold)]">
-                Marcel Duchamp
-              </p>
-              <DialogPrimitive.Title className="font-serif text-xl leading-tight text-[var(--text-primary)] sm:text-[1.45rem]">
+          <div className="flex min-h-0 flex-col overflow-y-auto border-t border-[var(--pane-edge)] md:border-l md:border-t-0">
+            <div className="space-y-1.5 border-b border-[var(--pane-edge)] px-6 pb-5 pt-6">
+              <p className="eyebrow eyebrow--gold">Marcel Duchamp</p>
+              <DialogPrimitive.Title className="font-serif text-xl leading-tight text-[var(--paper)] sm:text-[1.45rem]">
                 {artwork.title}
               </DialogPrimitive.Title>
               {artwork.artwork.year && (
-                <p className="font-serif text-sm italic text-[var(--text-tertiary)]">
+                <p className="font-serif text-sm italic text-[var(--paper-dimmer)]">
                   {artwork.artwork.year}
                 </p>
               )}
             </div>
 
             {hasMeta && (
-              <dl className="space-y-4 border-b border-[rgb(201_169_97/0.12)] px-6 py-5">
+              <dl className="space-y-4 border-b border-[var(--pane-edge)] px-6 py-5">
                 {artwork.artwork.medium && (
                   <MetaPair label="Medium">{artwork.artwork.medium}</MetaPair>
                 )}
@@ -133,7 +117,7 @@ export function WorkDetailModal({ artwork, open, onOpenChange }: WorkDetailModal
                       href={artwork.artwork.sourceUrl}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="inline-flex items-center gap-1.5 text-[var(--accent-gold)] transition-colors hover:text-[var(--text-primary)]"
+                      className="dig-link inline-flex items-center gap-1.5 transition-colors hover:text-[var(--paper)]"
                     >
                       External record
                       <ExternalLink className="h-3.5 w-3.5" />
@@ -144,12 +128,12 @@ export function WorkDetailModal({ artwork, open, onOpenChange }: WorkDetailModal
             )}
 
             {artwork.description && (
-              <blockquote className="relative border-b border-[rgb(201_169_97/0.12)] px-6 py-5">
+              <blockquote className="relative border-b border-[var(--pane-edge)] px-6 py-5">
                 <span
                   aria-hidden
-                  className="absolute left-6 top-5 h-[calc(100%-2.5rem)] w-0.5 bg-[var(--accent-gold)] opacity-60"
+                  className="absolute left-6 top-5 h-[calc(100%-2.5rem)] w-0.5 bg-[var(--gold)] opacity-60"
                 />
-                <p className="pl-4 font-serif text-sm italic leading-relaxed text-[var(--text-secondary)]">
+                <p className="pl-4 font-serif text-sm italic leading-relaxed text-[var(--paper-dim)]">
                   {artwork.description}
                 </p>
               </blockquote>
@@ -160,7 +144,7 @@ export function WorkDetailModal({ artwork, open, onOpenChange }: WorkDetailModal
                 <Link
                   href={`/${artwork.artwork.articleSlug}` as never}
                   onClick={() => onOpenChange(false)}
-                  className="group inline-flex w-full items-center justify-between gap-3 rounded-sm border border-[rgb(201_169_97/0.35)] bg-[rgba(201,169,97,0.04)] px-4 py-3 font-serif text-sm text-[var(--accent-gold)] transition-all hover:border-[var(--accent-gold)] hover:bg-[rgba(201,169,97,0.1)] hover:text-[var(--text-primary)]"
+                  className="group inline-flex w-full items-center justify-between gap-3 rounded-sm border border-[color-mix(in_srgb,var(--gold)_35%,transparent)] bg-[color-mix(in_srgb,var(--gold)_4%,transparent)] px-4 py-3 font-serif text-sm text-[var(--gold)] transition-all hover:border-[var(--gold)] hover:bg-[color-mix(in_srgb,var(--gold)_10%,transparent)] hover:text-[var(--paper)]"
                 >
                   <span>Read full article</span>
                   <ArrowUpRight className="h-4 w-4 transition-transform duration-300 group-hover:-translate-y-0.5 group-hover:translate-x-0.5" />


### PR DESCRIPTION
## What

Converges the Duchamp works tile and artwork detail modal onto the shared Delay style system.

## Why

Issue #40 is reducing style drift across the site. The Duchamp works tile/modal pair was the next compact visual slice with concentrated legacy token, raw color, and inline style usage.

## Changes

- Replaces legacy visual tokens
- Removes raw modal style objects
- Keeps modal behavior intact
- Preserves tile hover behavior

## Testing

- npm run audit:styles
- npm run format:check
- npm run build
- Visual review on localhost:4002
